### PR TITLE
Fix typo in example of `oci_image`

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -21,7 +21,7 @@ oci_image(
         "rootfs.tar",
         "appfs.tar",
         "libc6.tar",
-        "passwd.tar,
+        "passwd.tar",
     ]
 )
 ```

--- a/oci/private/image.bzl
+++ b/oci/private/image.bzl
@@ -11,7 +11,7 @@ oci_image(
         "rootfs.tar",
         "appfs.tar",
         "libc6.tar",
-        "passwd.tar,
+        "passwd.tar",
     ]
 )
 ```


### PR DESCRIPTION
This PR fixes a typo in the example of `oci_image` rule.