### PR TITLE
Cache results per OS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
             ~/.cache/bazel
             ~/.cache/bazel-repo
           key: bazel-cache-${{ matrix.os }}-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'WORKSPACE') }}
-          restore-keys: bazel-cache-
+          restore-keys: bazel-cache-${{ matrix.os }}
       - name: install podman
         if: ${{ matrix.os == 'macos-latest' }}
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
           path: |
             ~/.cache/bazel
             ~/.cache/bazel-repo
-          key: bazel-cache-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'WORKSPACE') }}
+          key: bazel-cache-${{ matrix.os }}-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'WORKSPACE') }}
           restore-keys: bazel-cache-
       - name: install podman
         if: ${{ matrix.os == 'macos-latest' }}


### PR DESCRIPTION
Currently, GitHub Actions caches on macOS are not uploaded because the key is shared between Ubuntu and macOS and, because CI in Ubuntu normally finishes much earlier (See screenshot of macOS build below). This prevents Bazel on macOS from fully taking advantage of GitHub Actions caches. (macOS runner always downloads caches built by the Ubuntu runner, but those caches are not always usable for macOS such as Go object files)
This PR allows to use cache keys per OS so that caches can be used on macOS.

<img width="1207" alt="Screenshot 2023-01-13 at 10 19 56" src="https://user-images.githubusercontent.com/1183444/212215747-f519711f-04b8-421f-8a88-83d72411db47.png">
