### PR TITLE
fix: url to download bazel-skylib

### DIFF
--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -39,7 +39,7 @@ def rules_oci_internal_deps():
         sha256 = "07b4117379dde7ab382345c3b0f5edfc6b7cff6c93756eac63da121e0bbcc5de",
         strip_prefix = "bazel-skylib-1.1.1",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/archive/1.1.1.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
             "https://github.com/bazelbuild/bazel-skylib/archive/1.1.1.tar.gz",
         ],
     )


### PR DESCRIPTION
This PR fixes the URL to download bazel-skylib. Currently, we get the warning something like:

```shell
$ bazel test //example/js:test
...
WARNING: Download from https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/archive/1.1.1.tar.gz failed: class java.io.FileNotFoundException GET returned 404 Not Found
```

The correct form should be

`https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/<VERSION>/bazel-skylib-
<VERSION>.tar.gz`

where `VERSION` is a version number.
(ref: https://github.com/bazelbuild/bazel-skylib/releases/tag/1.1.1)