### PR TITLE
Add labels to oci_image

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -7,12 +7,12 @@ Implementation details for image rule
 ## oci_image
 
 <pre>
-oci_image(<a href="#oci_image-name">name</a>, <a href="#oci_image-architecture">architecture</a>, <a href="#oci_image-base">base</a>, <a href="#oci_image-cmd">cmd</a>, <a href="#oci_image-entrypoint">entrypoint</a>, <a href="#oci_image-env">env</a>, <a href="#oci_image-os">os</a>, <a href="#oci_image-tars">tars</a>, <a href="#oci_image-user">user</a>, <a href="#oci_image-variant">variant</a>, <a href="#oci_image-workdir">workdir</a>)
+oci_image(<a href="#oci_image-name">name</a>, <a href="#oci_image-architecture">architecture</a>, <a href="#oci_image-base">base</a>, <a href="#oci_image-cmd">cmd</a>, <a href="#oci_image-entrypoint">entrypoint</a>, <a href="#oci_image-env">env</a>, <a href="#oci_image-labels">labels</a>, <a href="#oci_image-os">os</a>, <a href="#oci_image-tars">tars</a>, <a href="#oci_image-user">user</a>, <a href="#oci_image-variant">variant</a>, <a href="#oci_image-workdir">workdir</a>)
 </pre>
 
 Build an OCI compatible container image.
 
-It takes number of tar files as layers to create image filesystem. 
+It takes number of tar files as layers to create image filesystem.
 For incrementality, use more fine grained tar files to build up the filesystem.
 
 ```starlark
@@ -37,7 +37,7 @@ oci_image(
 )
 ```
 
-To combine `env` with environment variables from the `base`, bash style variable syntax MAYBE used. 
+To combine `env` with environment variables from the `base`, bash style variable syntax MAYBE used.
 
 ```starlark
 oci_image(
@@ -64,9 +64,10 @@ oci_image(
 | <a id="oci_image-cmd"></a>cmd |  Default arguments to the <code>entrypoint</code> of the container. These values act as defaults and may be replaced by any specified when creating a container.   | List of strings | optional | [] |
 | <a id="oci_image-entrypoint"></a>entrypoint |  A list of arguments to use as the <code>command</code> to execute when the container starts. These values act as defaults and may be replaced by an entrypoint specified when creating a container.   | List of strings | optional | [] |
 | <a id="oci_image-env"></a>env |  Default values to the environment variables of the container. These values act as defaults and are merged with any specified when creating a container. Entries replace the base environment variables if any of the entries has conflicting keys. To merge entries with keys specified in the base, <code>${KEY}</code> or <code>$KEY</code> syntax may be used.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
+| <a id="oci_image-labels"></a>labels |  Labels for the image config. See https://github.com/opencontainers/image-spec/blob/main/annotations.md.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="oci_image-os"></a>os |  The name of the operating system which the image is built to run on. eg: <code>linux</code>, <code>windows</code>. See $GOOS documentation for possible values: https://go.dev/doc/install/source#environment   | String | optional | "" |
 | <a id="oci_image-tars"></a>tars |  List of tar files to add to the image as layers.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="oci_image-user"></a>user |  The <code>username</code> or <code>UID</code> which is a platform-specific structure that allows specific control over which user the process run as.  This acts as a default value to use when the value is not specified when creating a container.  For Linux based systems, all of the following are valid: <code>user</code>, <code>uid</code>, <code>user:group</code>, <code>uid:gid</code>, <code>uid:group</code>, <code>user:gid</code>.  If <code>group/gid</code> is not specified, the default group and supplementary groups of the given <code>user/uid</code> in <code>/etc/passwd</code> from the container are applied.   | String | optional | "" |
+| <a id="oci_image-user"></a>user |  The <code>username</code> or <code>UID</code> which is a platform-specific structure that allows specific control over which user the process run as. This acts as a default value to use when the value is not specified when creating a container. For Linux based systems, all of the following are valid: <code>user</code>, <code>uid</code>, <code>user:group</code>, <code>uid:gid</code>, <code>uid:group</code>, <code>user:gid</code>. If <code>group/gid</code> is not specified, the default group and supplementary groups of the given <code>user/uid</code> in <code>/etc/passwd</code> from the container are applied.   | String | optional | "" |
 | <a id="oci_image-variant"></a>variant |  The variant of the specified CPU architecture. eg: <code>v6</code>, <code>v7</code>, <code>v8</code>. See: https://github.com/opencontainers/image-spec/blob/main/image-index.md#platform-variants for more.   | String | optional | "" |
 | <a id="oci_image-workdir"></a>workdir |  Sets the current working directory of the <code>entrypoint</code> process in the container. This value acts as a default and may be replaced by a working directory specified when creating a container.   | String | optional | "" |
 

--- a/examples/labels/BUILD.bazel
+++ b/examples/labels/BUILD.bazel
@@ -1,0 +1,29 @@
+load("//oci:defs.bzl", "oci_image", "structure_test")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
+
+pkg_tar(
+    name = "app",
+    srcs = ["test.bash"],
+)
+
+oci_image(
+    name = "image",
+    architecture = select({
+        "@platforms//cpu:arm64": "arm64",
+        "@platforms//cpu:x86_64": "amd64",
+    }),
+    base = "//examples:base",
+    cmd = ["test.sh"],
+    labels = {
+        "org.opencontainers.image.version": "xxx",
+        "org.opencontainers.image.source": "https://github.com/bazel-contrib/rules_oci",
+    },
+    os = "linux",
+    tars = ["app.tar"],
+)
+
+structure_test(
+    name = "test",
+    config = ["test.yaml"],
+    image = ":image",
+)

--- a/examples/labels/test.bash
+++ b/examples/labels/test.bash
@@ -1,0 +1,1 @@
+echo "hello world!"

--- a/examples/labels/test.yaml
+++ b/examples/labels/test.yaml
@@ -1,0 +1,14 @@
+schemaVersion: "2.0.0"
+
+commandTests:
+  - name: "echo hello"
+    command: "bash"
+    args: ["test.bash"]
+    expectedOutput: ["hello world!"]
+
+metadataTest:
+  labels:
+    - key: "org.opencontainers.image.version"
+      value: "xxx"
+    - key: "org.opencontainers.image.source"
+      value: "https://github.com/bazel-contrib/rules_oci"

--- a/oci/private/image.bzl
+++ b/oci/private/image.bzl
@@ -2,7 +2,7 @@
 
 _DOC = """Build an OCI compatible container image.
 
-It takes number of tar files as layers to create image filesystem. 
+It takes number of tar files as layers to create image filesystem.
 For incrementality, use more fine grained tar files to build up the filesystem.
 
 ```starlark
@@ -27,7 +27,7 @@ oci_image(
 )
 ```
 
-To combine `env` with environment variables from the `base`, bash style variable syntax MAYBE used. 
+To combine `env` with environment variables from the `base`, bash style variable syntax MAYBE used.
 
 ```starlark
 oci_image(
@@ -53,15 +53,16 @@ Default values to the environment variables of the container. These values act a
 To merge entries with keys specified in the base, `${KEY}` or `$KEY` syntax may be used.
 """),
     "user": attr.string(doc = """
-The `username` or `UID` which is a platform-specific structure that allows specific control over which user the process run as. 
-This acts as a default value to use when the value is not specified when creating a container. 
-For Linux based systems, all of the following are valid: `user`, `uid`, `user:group`, `uid:gid`, `uid:group`, `user:gid`. 
+The `username` or `UID` which is a platform-specific structure that allows specific control over which user the process run as.
+This acts as a default value to use when the value is not specified when creating a container.
+For Linux based systems, all of the following are valid: `user`, `uid`, `user:group`, `uid:gid`, `uid:group`, `user:gid`.
 If `group/gid` is not specified, the default group and supplementary groups of the given `user/uid` in `/etc/passwd` from the container are applied.
 """),
     "workdir": attr.string(doc = "Sets the current working directory of the `entrypoint` process in the container. This value acts as a default and may be replaced by a working directory specified when creating a container."),
     "os": attr.string(doc = "The name of the operating system which the image is built to run on. eg: `linux`, `windows`. See $GOOS documentation for possible values: https://go.dev/doc/install/source#environment"),
     "architecture": attr.string(doc = "The CPU architecture which the binaries in this image are built to run on. eg: `arm64`, `arm`, `amd64`, `s390x`. See $GOARCH documentation for possible values: https://go.dev/doc/install/source#environment"),
     "variant": attr.string(doc = "The variant of the specified CPU architecture. eg: `v6`, `v7`, `v8`. See: https://github.com/opencontainers/image-spec/blob/main/image-index.md#platform-variants for more."),
+    "labels": attr.string_dict(doc = "Labels for the image config. See https://github.com/opencontainers/image-spec/blob/main/annotations.md."),
     "_image_sh_tpl": attr.label(default = "image.sh.tpl", allow_single_file = True),
 }
 
@@ -137,6 +138,10 @@ def _oci_image_impl(ctx):
 
     if ctx.attr.env:
         args.add_all(ctx.attr.env.items(), map_each = _format_string_to_string_tuple, format_each = "--env=%s")
+
+    if ctx.attr.labels:
+        # TODO: Support stamping the values
+        args.add_all(ctx.attr.labels.items(), map_each = _format_string_to_string_tuple, format_each = "--label=%s")
 
     output = ctx.actions.declare_directory(ctx.label.name)
     args.add(output.path, format = "--output=%s")

--- a/oci/tests/BUILD.bazel
+++ b/oci/tests/BUILD.bazel
@@ -6,8 +6,8 @@ load("@aspect_bazel_lib//lib:diff_test.bzl", "diff_test")
         name = "pull_{image}".format(image = image),
         outs = [image],
         cmd = "$(CRANE_BIN) pull gcr.io/distroless/{image}@{digest} $@ --format=oci --platform=linux/amd64".format(
-            image = image,
             digest = digest,
+            image = image,
         ),
         local = True,  # needs to run locally to able to use credential helpers
         message = "Pulling gcr.io/distroless/{image} for linux/amd64".format(image = image),


### PR DESCRIPTION
Fixes https://github.com/bazel-contrib/rules_oci/issues/47

I would like to have stamping support before merging this PR. I see @alexeagle is working on stamping in https://github.com/bazel-contrib/rules_oci/pull/70.

From what I understand, the script that builds the image will need to read the volatile and stable files when stamping is enabled, and do variable substitution for each key (if found). Should I try something like https://github.com/aspect-build/bazel-lib/blob/998ee223690ed07b3dfc31738dae839206bd60b0/lib/tests/stamping/stamper.sh ? Or is there a more native alternative for stamping?