### PR TITLE
FIX: Github Workflows Release template

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -27,7 +27,7 @@ http_archive(
 # you should fetch it *before* calling this.
 # Alternatively, you can skip calling this function, so long as you've
 # already fetched all the dependencies.
-load("@contrib_rules_oci//oci:repositories.bzl", "rules_oci_dependencies")
+load("@contrib_rules_oci//oci:dependencies.bzl", "rules_oci_dependencies")
 rules_oci_dependencies()
 
 \`\`\`


### PR DESCRIPTION
*Changes*

GitHub Release Workflow has the incorrect location for the `rules_oci_dependencies` rule. Changed `.github/workflows/release_prep.sh` from:
```
load("@contrib_rules_oci//oci:repositories.bzl", "rules_oci_dependencies")
```
to
```
load("@contrib_rules_oci//oci:dependencies.bzl", "rules_oci_dependencies")
```