### PR TITLE
fix: rust does not have a 2022 edition

### DIFF
--- a/e2e/wasm/WORKSPACE
+++ b/e2e/wasm/WORKSPACE
@@ -45,4 +45,4 @@ load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_regi
 
 rules_rust_dependencies()
 
-rust_register_toolchains(edition = "2022")
+rust_register_toolchains(edition = "2021")

--- a/e2e/wasm/main.rs
+++ b/e2e/wasm/main.rs
@@ -1,4 +1,4 @@
-
 fn main() {
     println!("Hello world!");
 }
+


### PR DESCRIPTION
Small fix. 

Rust does not have a 2022 edition. It's current editions are 2015, 2018 and 2021.

See: https://doc.rust-lang.org/edition-guide/