### PR TITLE
feat: support the driver argument of container-test

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 docs/cosign*.md
 docs/image*.md
+docs/structure*.md
 docs/pull.md
 docs/push.md
 docs/tarball.md

--- a/docs/structure_test.md
+++ b/docs/structure_test.md
@@ -7,18 +7,20 @@ test rule running structure_test against an oci_image.
 ## structure_test
 
 <pre>
-structure_test(<a href="#structure_test-name">name</a>, <a href="#structure_test-config">config</a>, <a href="#structure_test-image">image</a>)
+structure_test(<a href="#structure_test-name">name</a>, <a href="#structure_test-config">config</a>, <a href="#structure_test-driver">driver</a>, <a href="#structure_test-image">image</a>, <a href="#structure_test-image_tar">image_tar</a>)
 </pre>
 
-Tests an oci_image in a container runtime by using GoogleContainerTools/container-structure-test.
+Tests an oci_image by using [container-structure-test](https://github.com/GoogleContainerTools/container-structure-test).
 
-It relies on the container runtime already installed and running on the target. 
-
+By default, it relies on the container runtime already installed and running on the target.
 By default, container-structure-test uses the socket available at /var/run/docker.sock. If the installation
 creates the socket in a different path, use --test_env=DOCKER_HOST='unix://<path_to_sock>'.
 
 To avoid putting this into the commandline or to instruct bazel to read it from terminal environment, 
 simply drop `test --test_env=DOCKER_HOST` into the .bazelrc file.
+
+Alternatively, use the `driver = "tar"` attribute to avoid the need for a container runtime, see
+https://github.com/GoogleContainerTools/container-structure-test#running-file-tests-without-docker
 
 
 **ATTRIBUTES**
@@ -28,6 +30,8 @@ simply drop `test --test_env=DOCKER_HOST` into the .bazelrc file.
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="structure_test-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a id="structure_test-config"></a>config |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
-| <a id="structure_test-image"></a>image |  Label to an oci_image target   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| <a id="structure_test-driver"></a>driver |  See https://github.com/GoogleContainerTools/container-structure-test#running-file-tests-without-docker   | String | optional | "docker" |
+| <a id="structure_test-image"></a>image |  Label to an oci_image target. Only works when <code>driver</code> is <code>docker</code>.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| <a id="structure_test-image_tar"></a>image_tar |  Label of an oci_tarball target. Only one of <code>image</code> and <code>image_tar</code> should be used.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 

--- a/docs/structure_test.md
+++ b/docs/structure_test.md
@@ -7,7 +7,7 @@ test rule running structure_test against an oci_image.
 ## structure_test
 
 <pre>
-structure_test(<a href="#structure_test-name">name</a>, <a href="#structure_test-config">config</a>, <a href="#structure_test-driver">driver</a>, <a href="#structure_test-image">image</a>, <a href="#structure_test-image_tar">image_tar</a>)
+structure_test(<a href="#structure_test-name">name</a>, <a href="#structure_test-config">config</a>, <a href="#structure_test-driver">driver</a>, <a href="#structure_test-image">image</a>)
 </pre>
 
 Tests an oci_image by using [container-structure-test](https://github.com/GoogleContainerTools/container-structure-test).
@@ -31,7 +31,6 @@ https://github.com/GoogleContainerTools/container-structure-test#running-file-te
 | <a id="structure_test-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a id="structure_test-config"></a>config |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
 | <a id="structure_test-driver"></a>driver |  See https://github.com/GoogleContainerTools/container-structure-test#running-file-tests-without-docker   | String | optional | "docker" |
-| <a id="structure_test-image"></a>image |  Label to an oci_image target. Only works when <code>driver</code> is <code>docker</code>.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
-| <a id="structure_test-image_tar"></a>image_tar |  Label of an oci_tarball target. Only one of <code>image</code> and <code>image_tar</code> should be used.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| <a id="structure_test-image"></a>image |  Label of an oci_image or oci_tarball target.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 

--- a/e2e/smoke/BUILD.bazel
+++ b/e2e/smoke/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_oci//oci:defs.bzl", "oci_image", "structure_test")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_tarball", "structure_test")
 
 oci_image(
     name = "image",
@@ -17,8 +17,15 @@ oci_image(
     os = "linux",
 )
 
+oci_tarball(
+    name = "tar",
+    image = ":image",
+    repotags = [],
+)
+
 structure_test(
     name = "test",
     config = ["test.yaml"],
-    image = ":image",
+    driver = "tar",
+    image_tar = ":tar",
 )

--- a/e2e/smoke/BUILD.bazel
+++ b/e2e/smoke/BUILD.bazel
@@ -27,5 +27,5 @@ structure_test(
     name = "test",
     config = ["test.yaml"],
     driver = "tar",
-    image_tar = ":tar",
+    image = ":tar",
 )

--- a/e2e/smoke/WORKSPACE.bazel
+++ b/e2e/smoke/WORKSPACE.bazel
@@ -18,3 +18,8 @@ oci_register_toolchains(
     crane_version = LATEST_CRANE_VERSION,
     zot_version = LATEST_ZOT_VERSION,
 )
+
+# Optional, for oci_tarball rule
+load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+
+rules_pkg_dependencies()

--- a/oci/private/structure_test.bzl
+++ b/oci/private/structure_test.bzl
@@ -1,19 +1,35 @@
 """test rule running structure_test against an oci_image."""
 
-_DOC = """Tests an oci_image in a container runtime by using GoogleContainerTools/container-structure-test.
+_DOC = """Tests an oci_image by using [container-structure-test](https://github.com/GoogleContainerTools/container-structure-test).
 
-It relies on the container runtime already installed and running on the target. 
-
+By default, it relies on the container runtime already installed and running on the target.
 By default, container-structure-test uses the socket available at /var/run/docker.sock. If the installation
 creates the socket in a different path, use --test_env=DOCKER_HOST='unix://<path_to_sock>'.
 
 To avoid putting this into the commandline or to instruct bazel to read it from terminal environment, 
 simply drop `test --test_env=DOCKER_HOST` into the .bazelrc file.
+
+Alternatively, use the `driver = "tar"` attribute to avoid the need for a container runtime, see
+https://github.com/GoogleContainerTools/container-structure-test#running-file-tests-without-docker
 """
 
 _attrs = {
-    "image": attr.label(mandatory = True, allow_single_file = True, doc = "Label to an oci_image target"),
+    "image": attr.label(
+        allow_single_file = True,
+        doc = "Label to an oci_image target. Only works when `driver` is `docker`.",
+        # TODO: restrict valid values using providers = ["OciImage"] when we have that.
+    ),
+    "image_tar": attr.label(
+        allow_single_file = [".tar"],
+        doc = "Label of an oci_tarball target. Only one of `image` and `image_tar` should be used.",
+    ),
     "config": attr.label_list(allow_files = True, mandatory = True),
+    "driver": attr.string(
+        default = "docker",
+        # https://github.com/GoogleContainerTools/container-structure-test/blob/5e347b66fcd06325e3caac75ef7dc999f1a9b614/pkg/drivers/driver.go#L26-L28
+        values = ["docker", "tar", "host"],
+        doc = "See https://github.com/GoogleContainerTools/container-structure-test#running-file-tests-without-docker",
+    ),
 }
 
 CMD = """\
@@ -28,10 +44,20 @@ def _structure_test_impl(ctx):
     st_info = ctx.toolchains["@rules_oci//oci:st_toolchain_type"].st_info
     yq_info = ctx.toolchains["@aspect_bazel_lib//lib:yq_toolchain_type"].yqinfo
 
-    fixed_args = [
-        "--image-from-oci-layout",
-        ctx.file.image.short_path,
-    ]
+    if ctx.attr.image and ctx.attr.image_tar:
+        fail("Only one of 'image' and 'image_tar' attributes should be used.")
+
+    # https://github.com/GoogleContainerTools/container-structure-test/blob/5e347b66fcd06325e3caac75ef7dc999f1a9b614/cmd/container-structure-test/app/cmd/test.go#L110
+    if ctx.attr.image and ctx.attr.driver != "docker":
+        fail("'image' attribute may only be used with 'driver=docker'")
+
+    fixed_args = ["--driver", ctx.attr.driver]
+    if ctx.file.image:
+        image_path = ctx.file.image.short_path
+        fixed_args.extend(["--image-from-oci-layout", image_path])
+    else:
+        image_path = ctx.file.image_tar.short_path
+        fixed_args.extend(["--image", image_path])
 
     for arg in ctx.files.config:
         fixed_args.append("--config=%s" % arg.path)
@@ -43,12 +69,12 @@ def _structure_test_impl(ctx):
             st_path = st_info.binary.short_path,
             fixed_args = " ".join(fixed_args),
             yq_path = yq_info.bin.short_path,
-            image_path = ctx.file.image.short_path,
+            image_path = image_path,
         ),
         is_executable = True,
     )
 
-    runfiles = ctx.runfiles(files = ctx.files.image + ctx.files.config + [st_info.binary, yq_info.bin])
+    runfiles = ctx.runfiles(files = ctx.files.image + ctx.files.image_tar + ctx.files.config + [st_info.binary, yq_info.bin])
 
     return DefaultInfo(runfiles = runfiles, executable = launcher)
 

--- a/oci/private/tarball.bzl
+++ b/oci/private/tarball.bzl
@@ -87,7 +87,9 @@ def _tarball_impl(ctx):
 
     tarball = _tar_tarball(ctx, blobs, manifest)
 
-    return DefaultInfo(files = depset([tarball]))
+    return [
+        DefaultInfo(files = depset([tarball])),
+    ]
 
 oci_tarball = rule(
     implementation = _tarball_impl,


### PR DESCRIPTION
This allows many tests to run on a platform with no container runtime, like the BCR presubmit