### PR TITLE
chore: don't use symlink for e2e bazelrc

### DIFF
--- a/e2e/smoke/.bazelrc
+++ b/e2e/smoke/.bazelrc
@@ -1,1 +1,1 @@
-../../.bazelrc
+test --test_env=DOCKER_HOST


### PR DESCRIPTION
It seems to be broken on BCR windows presubmit:
https://buildkite.com/bazel/bcr-presubmit/builds/1117#0186d6d0-96a6-44c8-8176-93c67cfdebac
```

  File c:bbk-windows-58ckbazelbcr-presubmitbcr_presubmit.py, line 240, in prepare_test_module_repo
    scratch_file(test_module_root, .bazelrc, [
  File c:bbk-windows-58ckbazelbcr-presubmitbcr_presubmit.py, line 147, in scratch_file
    with open(abspath, mode) as f:
OSError: [Errno 22] Invalid argument: 'c:\b\bk-windows-58ck\bazel-downstream-projects\output\rules_oci-0.3.4\e2e\smoke\.bazelrc'
```