### PR TITLE
fix: structure test platform keys include .exe suffix on windows

### DIFF
--- a/oci/repositories.bzl
+++ b/oci/repositories.bzl
@@ -90,6 +90,8 @@ def _stucture_test_repo_impl(repository_ctx):
     # TODO: fix this upstream asking distroless people
     if platform.find("darwin") != -1:
         platform = platform.replace("arm64", "amd64")
+    elif platform.find("windows") != -1:
+        platform = platform + ".exe"
     url = "https://github.com/GoogleContainerTools/container-structure-test/releases/download/{version}/container-structure-test-{platform}".format(
         version = repository_ctx.attr.st_version,
         platform = platform,


### PR DESCRIPTION
It's defined here: https://github.com/bazel-contrib/rules_oci/blob/main/oci/private/versions.bzl#L35

Fixes #97