### PR TITLE
chore: mirror new crane version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,7 +13,7 @@ bazel_dep(name = "platforms", version = "0.0.5")
 
 oci = use_extension("//oci:extensions.bzl", "oci")
 oci.toolchains(
-    crane_version = "v0.12.0",
+    crane_version = "v0.14.0",
     zot_version = "v1.4.3-rc3",
 )
 use_repo(oci, "oci_crane_toolchains", "oci_zot_toolchains", "oci_st_toolchains")

--- a/oci/private/versions.bzl
+++ b/oci/private/versions.bzl
@@ -2,6 +2,18 @@
 
 # WARNING: only v0.12.0 and above is supported.
 CRANE_VERSIONS = {
+    "v0.14.0": {
+        "darwin_arm64": "sha256-8g+3rziZKW/OK2YPTHUWmvFDUhX6/zXInY/tVZaOb2E=",
+        "darwin_x86_64": "sha256-h+vdsXSnfez8MUgLMPLLg7tVqeyyRSxSJBatC/+yPRY=",
+        "linux_arm64": "sha256-8QeMgjli2vFNI9QBVKZVELU2TompycffP5kfGen+tAE=",
+        "linux_armv6": "sha256-geo5WbuD4mq8/ay2veV3XGj03AoMLbwIB4CR4kcKKG4=",
+        "linux_i386": "sha256-aLzfhkWKUXfIJ7u4IJ9tg54Gu4aEBwJAkyS/1ZHVT/Q=",
+        "linux_s390x": "sha256-L2aEmQerb9+ZEEwg5ZikzJjzpC2bu6kw9C8J4kOwRMc=",
+        "linux_x86_64": "sha256-W2j+D3/pFwuj4Wd/R+z8iSxoei/cvCsd45q16WY95dc=",
+        "windows_arm64": "sha256-F0gUInC2psNFGV68DhSnn8AalX/wOHhd5SH0RAixYpg=",
+        "windows_armv6": "sha256-WoSZPcKgphu9RBaMrY1huXaU0JnTh2FrKoV5KQbXHzk=",
+        "windows_x86_64": "sha256-0ZbFoXN6Deo3yVLoHlygcn4hGXvXMF8iVradTlXGJNA=",
+    },
     "v0.12.0": {
         "darwin_arm64": "sha256-JGUx0myrqV3ZPktKiFrvn6SdhOBAmG61mCqjxYQnEa8=",
         "darwin_x86_64": "sha256-iO6yCJMD76cJWW5qncXShfaX/QT+6Q+DWURxo9WpQxs=",

--- a/scripts/mirror_releases.sh
+++ b/scripts/mirror_releases.sh
@@ -6,11 +6,10 @@ RAW=$(mktemp)
 
 REPOSITORY=${1:-"google/go-containerregistry"}
 
+# per_page=1 to just miror the most recent release
 (
   curl --silent \
     --header "Accept: application/vnd.github.v3+json" \
-    # NB: per_page=1 is here to ensure that we only listing releases above v0.12.0
-    # as of writing this there is only v0.12.0. 
     https://api.github.com/repos/${REPOSITORY}/releases?per_page=1 \
     | jq -f $SCRIPT_DIR/filter.jq
 ) > $RAW


### PR DESCRIPTION
```
% bazel run @oci_crane_darwin_arm64//:crane -- version
0.14.0
```

Unblocks us removing the custom registry for examples

Thanks @imjasonh