### PR TITLE
refactor: rename x86_64 to amd64

### DIFF
--- a/oci/private/toolchains_repo.bzl
+++ b/oci/private/toolchains_repo.bzl
@@ -20,7 +20,7 @@ with only the toolchain attribute pointing into the platform-specific repositori
 # Add more platforms as needed to mirror all the binaries
 # published by the upstream project.
 PLATFORMS = {
-    "darwin_x86_64": struct(
+    "darwin_amd64": struct(
         compatible_with = [
             "@platforms//os:macos",
             "@platforms//cpu:x86_64",
@@ -56,7 +56,7 @@ PLATFORMS = {
             "@platforms//cpu:s390x",
         ],
     ),
-    "linux_x86_64": struct(
+    "linux_amd64": struct(
         compatible_with = [
             "@platforms//os:linux",
             "@platforms//cpu:x86_64",
@@ -68,7 +68,7 @@ PLATFORMS = {
             "@platforms//cpu:arm64",
         ],
     ),
-    "windows_x86_64": struct(
+    "windows_amd64": struct(
         compatible_with = [
             "@platforms//os:windows",
             "@platforms//cpu:x86_64",

--- a/oci/repositories.bzl
+++ b/oci/repositories.bzl
@@ -25,15 +25,16 @@ registry_toolchain(
 """
 
 def _crane_repo_impl(repository_ctx):
+    platform = repository_ctx.attr.platform.replace("amd64", "x86_64")
     url = "https://github.com/google/go-containerregistry/releases/download/{version}/go-containerregistry_{platform}.tar.gz".format(
         version = repository_ctx.attr.crane_version,
-        platform = repository_ctx.attr.platform[:1].upper() + repository_ctx.attr.platform[1:],
+        platform = platform[:1].upper() + platform[1:],
     )
     repository_ctx.download_and_extract(
         url = url,
-        integrity = CRANE_VERSIONS[repository_ctx.attr.crane_version][repository_ctx.attr.platform],
+        integrity = CRANE_VERSIONS[repository_ctx.attr.crane_version][platform],
     )
-    binary = "crane.exe" if repository_ctx.attr.platform.startswith("windows_") else "crane"
+    binary = "crane.exe" if platform.startswith("windows_") else "crane"
     repository_ctx.template(
         "launcher.sh",
         repository_ctx.attr._launcher_tpl,
@@ -67,7 +68,7 @@ registry_toolchain(
 """
 
 def _zot_repo_impl(repository_ctx):
-    platform = repository_ctx.attr.platform.replace("x86_64", "amd64").replace("_", "-")
+    platform = repository_ctx.attr.platform.replace("_", "-")
     url = "https://github.com/project-zot/zot/releases/download/{version}/zot-{platform}".format(
         version = repository_ctx.attr.zot_version,
         platform = platform,
@@ -101,7 +102,7 @@ structure_test_toolchain(
 """
 
 def _stucture_test_repo_impl(repository_ctx):
-    platform = repository_ctx.attr.platform.replace("x86_64", "amd64").replace("_", "-")
+    platform = repository_ctx.attr.platform.replace("_", "-")
 
     # There is no arm64 version of structure test binary.
     # TODO: fix this upstream asking distroless people

--- a/oci/tests/BUILD.bazel
+++ b/oci/tests/BUILD.bazel
@@ -29,14 +29,10 @@ diff_test(
     file1 = "java17",
     # This one is declared with an oci_pull rule in /WORKSPACE
     file2 = "@distroless_java",
-    # TODO: https://github.com/bazel-contrib/rules_oci/issues/108
-    tags = ["manual"],
 )
 
 diff_test(
     name = "test_static",
     file1 = "static",
     file2 = "@distroless_static",
-    # TODO: https://github.com/bazel-contrib/rules_oci/issues/108
-    tags = ["manual"],
 )


### PR DESCRIPTION
Allows us to use `repo_utils.platform` and matches our other repositories. 