### PR TITLE
chore(bzlmod): add trivial pass-through module extension for oci_pull

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,10 +12,7 @@ bazel_dep(name = "rules_pkg", version = "0.8.1")
 bazel_dep(name = "platforms", version = "0.0.5")
 
 oci = use_extension("//oci:extensions.bzl", "oci")
-oci.toolchains(
-    crane_version = "v0.14.0",
-    zot_version = "v1.4.3-rc3",
-)
-use_repo(oci, "oci_crane_toolchains", "oci_zot_toolchains", "oci_st_toolchains")
+oci.toolchains(crane_version = "v0.14.0")
+use_repo(oci, "oci_crane_toolchains", "oci_crane_registry_toolchains", "oci_st_toolchains")
 
-register_toolchains("@oci_crane_toolchains//:all", "@oci_zot_toolchains//:all", "@oci_st_toolchains//:all")
+register_toolchains("@oci_crane_toolchains//:all", "@oci_crane_registry_toolchains//:all", "@oci_st_toolchains//:all")

--- a/oci/extensions.bzl
+++ b/oci/extensions.bzl
@@ -23,7 +23,7 @@ Base name for generated repositories, allowing more than one set of toolchains t
 Overriding the default is only permitted in the root module.
 """, default = "oci"),
     "crane_version": attr.string(doc = "Explicit version of crane.", mandatory = True),
-    "zot_version": attr.string(doc = "Explicit version of zot.", mandatory = True),
+    "zot_version": attr.string(doc = "Explicit version of zot. If not supplied, then only crane is used."),
 })
 
 def _oci_extension(module_ctx):

--- a/oci/extensions.bzl
+++ b/oci/extensions.bzl
@@ -1,6 +1,21 @@
 "extensions for bzlmod"
 
 load(":repositories.bzl", "oci_register_toolchains")
+load(":pull.bzl", "oci_pull")
+
+# TODO: it sucks that the API of the oci_pull macro has to be repeated here.
+pull = tag_class(attrs = {
+    "name": attr.string(doc = "Name of the generated repository"),
+    "image": attr.string(doc = """the remote image without a tag, such as gcr.io/bazel-public/bazel"""),
+    "platforms": attr.string_list(doc = """for multi-architecture images, a dictionary of the platforms it supports
+            This creates a separate external repository for each platform, avoiding fetching layers."""),
+    "digest": attr.string(doc = """the digest string, starting with "sha256:", "sha512:", etc.
+            If omitted, instructions for pinning are provided."""),
+    "tag": attr.string(doc = """a tag to choose an image from the registry.
+            Exactly one of `tag` and `digest` must be set.
+            Since tags are mutable, this is not reproducible, so a warning is printed."""),
+    "reproducible": attr.bool(doc = """Set to False to silence the warning about reproducibility when using `tag`.""", default = True),
+})
 
 toolchains = tag_class(attrs = {
     "name": attr.string(doc = """\
@@ -14,6 +29,15 @@ Overriding the default is only permitted in the root module.
 def _oci_extension(module_ctx):
     registrations = {}
     for mod in module_ctx.modules:
+        for pull in mod.tags.pull:
+            oci_pull(
+                name = pull.name,
+                image = pull.image,
+                platforms = pull.platforms,
+                digest = pull.digest,
+                tag = pull.tag,
+                reproducible = pull.reproducible,
+            )
         for toolchains in mod.tags.toolchains:
             if toolchains.name != "oci" and not mod.is_root:
                 fail("""\
@@ -37,6 +61,7 @@ def _oci_extension(module_ctx):
 oci = module_extension(
     implementation = _oci_extension,
     tag_classes = {
+        "pull": pull,
         "toolchains": toolchains,
     },
 )


### PR DESCRIPTION
However it trips over the labels in our generated build files making assumptions about repository names, needs some fixing