### PR TITLE
chore: bump rules_pkg to 0.9.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,7 +8,7 @@ module(
 
 bazel_dep(name = "aspect_bazel_lib", version = "1.28.0")
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
-bazel_dep(name = "rules_pkg", version = "0.8.1")
+bazel_dep(name = "rules_pkg", version = "0.9.0")
 bazel_dep(name = "platforms", version = "0.0.5")
 
 oci = use_extension("//oci:extensions.bzl", "oci")

--- a/oci/dependencies.bzl
+++ b/oci/dependencies.bzl
@@ -30,10 +30,10 @@ def rules_oci_dependencies():
     http_archive(
         name = "rules_pkg",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.7.1/rules_pkg-0.7.1.tar.gz",
-            "https://github.com/bazelbuild/rules_pkg/releases/download/0.7.1/rules_pkg-0.7.1.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.9.0/rules_pkg-0.9.0.tar.gz",
+            "https://github.com/bazelbuild/rules_pkg/releases/download/0.9.0/rules_pkg-0.9.0.tar.gz",
         ],
-        sha256 = "451e08a4d78988c06fa3f9306ec813b836b1d076d0f055595444ba4ff22b867f",
+        sha256 = "335632735e625d408870ec3e361e192e99ef7462315caa887417f4d88c4c8fb8",
     )
 
     http_archive(


### PR DESCRIPTION
The 0.8.1 release had a bzlmod compatibility_level change which makes errors for users that also have protobuf