### PR TITLE
Support OCI media types on pull in addition to docker media types

### DIFF
--- a/oci/dependencies.bzl
+++ b/oci/dependencies.bzl
@@ -33,7 +33,7 @@ def rules_oci_dependencies():
             "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.9.0/rules_pkg-0.9.0.tar.gz",
             "https://github.com/bazelbuild/rules_pkg/releases/download/0.9.0/rules_pkg-0.9.0.tar.gz",
         ],
-        sha256 = "335632735e625d408870ec3e361e192e99ef7462315caa887417f4d88c4c8fb8",
+        sha256 = "bcc96ae58d9d61db1a36a13d29e85dc2c1696ecb7997f9a26643ab0971ecb2ef",
     )
 
     http_archive(


### PR DESCRIPTION
This PR is composed of two commits:

1. Fixes a bug in `rules_pkg`'s sha256

2. Fixes #74. Adds support for OCI media types. Currently, `pull` only supports the media types from the docker standard, but it should also support the media types from the OCI standard.

Relevant specs:
* [Docker standard](https://github.com/distribution/distribution/blob/main/docs/spec/manifest-v2-2.md#media-types
) (already supported)
* [OCI standard](https://github.com/opencontainers/image-spec/blob/main/media-types.md) (support added in this PR)

Error this PR is fixing:

Setup:
```
bazel_dep(name = "aspect_bazel_lib", version = "1.29.2")
bazel_dep(name = "platforms", version = "0.0.5")
bazel_dep(name = "rules_oci", version = "0.3.8")
bazel_dep(name = "rules_pkg", version = "0.8.1")

oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
oci.pull(
    name = "distroless_cc",
    digest = "sha256:8aad707f96620ee89e27febef51b01c6ff244277a3560fcfcfbe68633ef09193",
    image = "gcr.io/distroless/cc",
    platforms = [
        "linux/amd64",
        "linux/arm64",
    ],
)
use_repo(oci, "distroless_cc")
```

Error message:
```
ERROR: An error occurred during the fetch of repository 'rules_oci~0.3.8~oci~distroless_cc_linux_arm64':
   Traceback (most recent call last):
        File "/private/var/tmp/_bazel_brian.myers/7c67ba1d63a5ecf4b1e2bbf1c99fe09a/external/rules_oci~0.3.8/oci/pull.bzl", line 333, column 13, in _oci_pull_impl
                fail("Unrecognized mediaType {} in manifest file".format(mf["mediaType"]))
Error in fail: Unrecognized mediaType application/vnd.oci.image.index.v1+json in manifest file
ERROR: <builtin>: fetching oci_pull_rule rule @rules_oci~0.3.8//oci:rules_oci~0.3.8~oci~distroless_cc_linux_arm64: Traceback (most recent call last):
        File "/private/var/tmp/_bazel_brian.myers/7c67ba1d63a5ecf4b1e2bbf1c99fe09a/external/rules_oci~0.3.8/oci/pull.bzl", line 333, column 13, in _oci_pull_impl
                fail("Unrecognized mediaType {} in manifest file".format(mf["mediaType"]))
Error in fail: Unrecognized mediaType application/vnd.oci.image.index.v1+json in manifest file
ERROR: /private/var/tmp/_bazel_brian.myers/7c67ba1d63a5ecf4b1e2bbf1c99fe09a/external/rules_oci~0.3.8~oci~distroless_cc/BUILD.bazel:1:6: @rules_oci~0.3.8~oci~distroless_cc//:distroless_cc depends on @rules_oci~0.3.8~oci~distroless_cc_linux_arm64//:distroless_cc_linux_arm64 in repository @rules_oci~0.3.8~oci~distroless_cc_linux_arm64 which failed to fetch. no such package '@rules_oci~0.3.8~oci~distroless_cc_linux_arm64//': Unrecognized mediaType application/vnd.oci.image.index.v1+json in manifest file
```