### PR TITLE
Fix bug with formatting of repotags in tarball manifest.json

### DIFF
--- a/oci/private/tarball.sh.tpl
+++ b/oci/private/tarball.sh.tpl
@@ -11,7 +11,6 @@ REPOTAGS=()
 # read repotags file as array and prepend it to REPOTAGS array.
 IFS=$'\n' REPOTAGSFILE=($(cat "$TAGS_FILE"))
 REPOTAGS=(${REPOTAGSFILE[@]+"${REPOTAGSFILE[@]}"} ${REPOTAGS[@]+"${REPOTAGS[@]}"})
-echo REPOTAGS: $REPOTAGS
 
 MANIFEST_DIGEST=$(${YQ} eval '.manifests[0].digest | sub(":"; "/")' "${IMAGE_DIR}/index.json")
 MANIFEST_BLOB_PATH="${IMAGE_DIR}/blobs/${MANIFEST_DIGEST}"
@@ -42,7 +41,6 @@ else
     done
     REPOTAGS_ARRAY=$REPOTAGS_ARRAY"]"
 fi
-echo REPOTAGS_ARRAY: $REPOTAGS_ARRAY
 
 config="blobs/${CONFIG_DIGEST}" \
 repotags="$REPOTAGS_ARRAY" \


### PR DESCRIPTION
The current tarball.sh.tpl script is generating a manifest.json file which formats the repotags as a string. 

Example:
```
[
  {
    "Config": "blobs/sha256/81e06113ed0b517fd70e4933d505b5f29a117e13edc50b5bba81af88c8f0effb",
    "RepoTags": "phono:latest",
    "Layers": [
      "blobs/sha256/6b0b1527d75b1e49c2cb08f4eb8616c64c9a20a8b9d8c1179146b2675586536b.tar.gz",
      "blobs/sha256/26e3e4b0848c0e87391a7a844b11fcd2e6d223bd516be6ac8b17bac4e6808609.tar.gz",
      "blobs/sha256/6670ae47b92addccf12843ef586edfbd7764c5d360e2ddc4a64e035625ce4bb9.tar.gz"
    ]
  }
]
```

But Docker attempts to parse the manifest with an array of strings for the repotags, resulting in this error:
```
json: cannot unmarshal string into Go struct field manifestItem.RepoTags of type []string
```

This PR updates the bash script to format the repo tags as an array of strings like this:
```
[
  {
    "Config": "blobs/sha256/81e06113ed0b517fd70e4933d505b5f29a117e13edc50b5bba81af88c8f0effb",
    "RepoTags": ["phono:latest"],
    "Layers": [
      "blobs/sha256/6b0b1527d75b1e49c2cb08f4eb8616c64c9a20a8b9d8c1179146b2675586536b.tar.gz",
      "blobs/sha256/26e3e4b0848c0e87391a7a844b11fcd2e6d223bd516be6ac8b17bac4e6808609.tar.gz",
      "blobs/sha256/6670ae47b92addccf12843ef586edfbd7764c5d360e2ddc4a64e035625ce4bb9.tar.gz"
    ]
  }
]
```

I tested loading this tar with docker which was successful:
```
2023/04/29 17:01:14 Using unreleased version at commit de5aac1daa152338131d06c1bc7e309e74cd2e4f
Loading: 
Loading: 
Loading: 0 packages loaded
Analyzing: target //apps/phono:tarball (0 packages loaded, 0 targets configured)
INFO: Analyzed target //apps/phono:tarball (26 packages loaded, 1381 targets configured).
INFO: Found 1 target...
INFO: Elapsed time: 0.215s, Critical Path: 0.00s
INFO: 0 processes.
INFO: Build completed successfully, 0 total actions
f1e5859e2f15: Loading layer [==================================================>]    821kB/821kB
3f53f0ab435d: Loading layer [==================================================>]   7.09MB/7.09MB
33fc041a7618: Loading layer [==================================================>]  11.72MB/11.72MB
Loaded image: phono:latest
```