### PR TITLE
fix: downgrade rules_pkg to 0.7.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,7 +8,7 @@ module(
 
 bazel_dep(name = "aspect_bazel_lib", version = "1.28.0")
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
-bazel_dep(name = "rules_pkg", version = "0.9.0")
+bazel_dep(name = "rules_pkg", version = "0.7.0")
 bazel_dep(name = "platforms", version = "0.0.5")
 
 oci = use_extension("//oci:extensions.bzl", "oci")

--- a/oci/dependencies.bzl
+++ b/oci/dependencies.bzl
@@ -33,7 +33,7 @@ def rules_oci_dependencies():
             "https://github.com/bazelbuild/rules_pkg/releases/download/0.9.0/rules_pkg-0.9.0.tar.gz",
             "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.9.0/rules_pkg-0.9.0.tar.gz",
         ],
-        sha256 = "bcc96ae58d9d61db1a36a13d29e85dc2c1696ecb7997f9a26643ab0971ecb2ef",
+        sha256 = "335632735e625d408870ec3e361e192e99ef7462315caa887417f4d88c4c8fb8",
     )
 
     http_archive(

--- a/oci/dependencies.bzl
+++ b/oci/dependencies.bzl
@@ -30,10 +30,10 @@ def rules_oci_dependencies():
     http_archive(
         name = "rules_pkg",
         urls = [
-            "https://github.com/bazelbuild/rules_pkg/releases/download/0.9.0/rules_pkg-0.9.0.tar.gz",
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.9.0/rules_pkg-0.9.0.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.8.1/rules_pkg-0.8.1.tar.gz",
+            "https://github.com/bazelbuild/rules_pkg/releases/download/0.8.1/rules_pkg-0.8.1.tar.gz",
         ],
-        sha256 = "335632735e625d408870ec3e361e192e99ef7462315caa887417f4d88c4c8fb8",
+        sha256 = "8c20f74bca25d2d442b327ae26768c02cf3c99e93fad0381f32be9aab1967675",
     )
 
     http_archive(

--- a/oci/dependencies.bzl
+++ b/oci/dependencies.bzl
@@ -30,8 +30,8 @@ def rules_oci_dependencies():
     http_archive(
         name = "rules_pkg",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.7.0/rules_pkg-0.7.0.tar.gz",
             "https://github.com/bazelbuild/rules_pkg/releases/download/0.7.0/rules_pkg-0.7.0.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.7.0/rules_pkg-0.7.0.tar.gz",
         ],
         sha256 = "8a298e832762eda1830597d64fe7db58178aa84cd5926d76d5b744d6558941c2",
     )

--- a/oci/dependencies.bzl
+++ b/oci/dependencies.bzl
@@ -30,10 +30,10 @@ def rules_oci_dependencies():
     http_archive(
         name = "rules_pkg",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.8.1/rules_pkg-0.8.1.tar.gz",
-            "https://github.com/bazelbuild/rules_pkg/releases/download/0.8.1/rules_pkg-0.8.1.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.7.0/rules_pkg-0.7.0.tar.gz",
+            "https://github.com/bazelbuild/rules_pkg/releases/download/0.7.0/rules_pkg-0.7.0.tar.gz",
         ],
-        sha256 = "8c20f74bca25d2d442b327ae26768c02cf3c99e93fad0381f32be9aab1967675",
+        sha256 = "8a298e832762eda1830597d64fe7db58178aa84cd5926d76d5b744d6558941c2",
     )
 
     http_archive(


### PR DESCRIPTION
can't use [0.9.0](https://github.com/bazelbuild/rules_pkg/releases/tag/0.9.0): broken digest
can't downgrade to [0.8.1](https://github.com/bazelbuild/rules_pkg/releases/tag/0.8.1):  compatibility level