### PR TITLE
Fix bug with formatting of repotags in tarball manifest.json [re-do]

### DIFF
--- a/oci/private/tarball.sh.tpl
+++ b/oci/private/tarball.sh.tpl
@@ -7,10 +7,11 @@ readonly BLOBS_DIR="{{blobs_dir}}"
 readonly TAGS_FILE="{{tags}}"
 readonly TARBALL_MANIFEST_PATH="{{manifest_path}}"
 
-REPOTAGS=()
-# read repotags file as array and prepend it to REPOTAGS array.
-IFS=$'\n' REPOTAGSFILE=($(cat "$TAGS_FILE"))
-REPOTAGS=(${REPOTAGSFILE[@]+"${REPOTAGSFILE[@]}"} ${REPOTAGS[@]+"${REPOTAGS[@]}"})
+# read repotags file as an array:
+SAVEIFS=$IFS   # Save current IFS (Internal Field Separator)
+IFS=$'\n'      # Change IFS to newline char
+REPOTAGS=$(cat "$TAGS_FILE")
+IFS=$SAVEIFS   # Restore original IFS
 
 MANIFEST_DIGEST=$(${YQ} eval '.manifests[0].digest | sub(":"; "/")' "${IMAGE_DIR}/index.json")
 MANIFEST_BLOB_PATH="${IMAGE_DIR}/blobs/${MANIFEST_DIGEST}"
@@ -28,8 +29,8 @@ for LAYER in $(${YQ} ".[]" <<< $LAYERS); do
 done
 
 config="blobs/${CONFIG_DIGEST}" \
-repotags="${REPOTAGS:-[]}" \
+repotags="${REPOTAGS}" \
 layers="${LAYERS}" \
 "${YQ}" eval \
-        --null-input '.[0] = {"Config": env(config), "RepoTags": env(repotags), "Layers": env(layers) | map( "blobs/" + . + ".tar.gz") }' \
+        --null-input '.[0] = {"Config": env(config), "RepoTags": env(repotags) | split(" "), "Layers": env(layers) | map( "blobs/" + . + ".tar.gz") }' \
         --output-format json > "${TARBALL_MANIFEST_PATH}"

--- a/oci/private/tarball.sh.tpl
+++ b/oci/private/tarball.sh.tpl
@@ -8,10 +8,7 @@ readonly TAGS_FILE="{{tags}}"
 readonly TARBALL_MANIFEST_PATH="{{manifest_path}}"
 
 # read repotags file as an array:
-SAVEIFS=$IFS   # Save current IFS (Internal Field Separator)
-IFS=$'\n'      # Change IFS to newline char
-REPOTAGS=$(cat "$TAGS_FILE")
-IFS=$SAVEIFS   # Restore original IFS
+REPOTAGS=$(IFS=$'\n' cat "$TAGS_FILE")
 
 # format the repotags as yaml:
 REPOTAGS_YAML=[]

--- a/oci/private/tarball.sh.tpl
+++ b/oci/private/tarball.sh.tpl
@@ -7,24 +7,7 @@ readonly BLOBS_DIR="{{blobs_dir}}"
 readonly TAGS_FILE="{{tags}}"
 readonly TARBALL_MANIFEST_PATH="{{manifest_path}}"
 
-# read repotags file as an array:
-REPOTAGS=$(IFS=$'\n' cat "$TAGS_FILE")
-
-# format the repotags as yaml:
-REPOTAGS_YAML=[]
-if [ -z "$REPOTAGS" ]
-then
-    REPOTAGS_YAML=[]
-else
-    REPOTAGS_YAML=[
-    for repotag in $REPOTAGS
-    do
-        REPOTAGS_YAML=$REPOTAGS_YAML\"
-        REPOTAGS_YAML=$REPOTAGS_YAML$repotag
-        REPOTAGS_YAML=$REPOTAGS_YAML\",
-    done
-    REPOTAGS_YAML=$REPOTAGS_YAML"]"
-fi
+REPOTAGS="$(cat "${TAGS_FILE}")"
 
 MANIFEST_DIGEST=$(${YQ} eval '.manifests[0].digest | sub(":"; "/")' "${IMAGE_DIR}/index.json")
 MANIFEST_BLOB_PATH="${IMAGE_DIR}/blobs/${MANIFEST_DIGEST}"
@@ -42,8 +25,8 @@ for LAYER in $(${YQ} ".[]" <<< $LAYERS); do
 done
 
 config="blobs/${CONFIG_DIGEST}" \
-repotags="${REPOTAGS_YAML}" \
+repotags="${REPOTAGS}" \
 layers="${LAYERS}" \
 "${YQ}" eval \
-        --null-input '.[0] = {"Config": env(config), "RepoTags": env(repotags), "Layers": env(layers) | map( "blobs/" + . + ".tar.gz") }' \
+        --null-input '.[0] = {"Config": strenv(config), "RepoTags": strenv(repotags) | split("\n"), "Layers": env(layers) | map( "blobs/" + . + ".tar.gz") }' \
         --output-format json > "${TARBALL_MANIFEST_PATH}"

--- a/oci/private/tarball.sh.tpl
+++ b/oci/private/tarball.sh.tpl
@@ -29,7 +29,7 @@ for LAYER in $(${YQ} ".[]" <<< $LAYERS); do
 done
 
 config="blobs/${CONFIG_DIGEST}" \
-repotags="${REPOTAGS}" \
+repotags="${REPOTAGS:-[]}" \
 layers="${LAYERS}" \
 "${YQ}" eval \
         --null-input '.[0] = {"Config": env(config), "RepoTags": env(repotags) | split(" "), "Layers": env(layers) | map( "blobs/" + . + ".tar.gz") }' \


### PR DESCRIPTION
The current tarball.sh.tpl script is generating a manifest.json file which formats the repotags as a string. 

Example:
```
[
  {
    "Config": "blobs/sha256/81e06113ed0b517fd70e4933d505b5f29a117e13edc50b5bba81af88c8f0effb",
    "RepoTags": "phono:latest",
    "Layers": [
      "blobs/sha256/6b0b1527d75b1e49c2cb08f4eb8616c64c9a20a8b9d8c1179146b2675586536b.tar.gz",
      "blobs/sha256/26e3e4b0848c0e87391a7a844b11fcd2e6d223bd516be6ac8b17bac4e6808609.tar.gz",
      "blobs/sha256/6670ae47b92addccf12843ef586edfbd7764c5d360e2ddc4a64e035625ce4bb9.tar.gz"
    ]
  }
]
```

But Docker attempts to parse the manifest with an array of strings for the repotags, resulting in this error:
```
json: cannot unmarshal string into Go struct field manifestItem.RepoTags of type []string
```

This PR updates the bash script to format the repo tags as an array of strings like this:
```
[
  {
    "Config": "blobs/sha256/81e06113ed0b517fd70e4933d505b5f29a117e13edc50b5bba81af88c8f0effb",
    "RepoTags": ["phono:latest"],
    "Layers": [
      "blobs/sha256/6b0b1527d75b1e49c2cb08f4eb8616c64c9a20a8b9d8c1179146b2675586536b.tar.gz",
      "blobs/sha256/26e3e4b0848c0e87391a7a844b11fcd2e6d223bd516be6ac8b17bac4e6808609.tar.gz",
      "blobs/sha256/6670ae47b92addccf12843ef586edfbd7764c5d360e2ddc4a64e035625ce4bb9.tar.gz"
    ]
  }
]
```

I tested loading this tar with docker which was successful:
```
2023/04/29 17:01:14 Using unreleased version at commit de5aac1daa152338131d06c1bc7e309e74cd2e4f
Loading: 
Loading: 
Loading: 0 packages loaded
Analyzing: target //apps/phono:tarball (0 packages loaded, 0 targets configured)
INFO: Analyzed target //apps/phono:tarball (26 packages loaded, 1381 targets configured).
INFO: Found 1 target...
INFO: Elapsed time: 0.215s, Critical Path: 0.00s
INFO: 0 processes.
INFO: Build completed successfully, 0 total actions
f1e5859e2f15: Loading layer [==================================================>]    821kB/821kB
3f53f0ab435d: Loading layer [==================================================>]   7.09MB/7.09MB
33fc041a7618: Loading layer [==================================================>]  11.72MB/11.72MB
Loaded image: phono:latest
```

There were actually two bugs in the script:
- The first was that the IFS was set to a newline when parsing the file (which was fine) but then the original IFS was never restored (it should normally be a space). This broke bash handling arrays later in the file, since arrays aren't really a type but an IFS separated string.
- The second was that, once I fixed that issue, the variable was still a space-separated string. I reformatted this into an array with square brackets and it worked as expected.