### PR TITLE
fix: extract image digest raw from yq

### DIFF
--- a/oci/private/push.sh.tpl
+++ b/oci/private/push.sh.tpl
@@ -71,7 +71,7 @@ REFERENCES=($(
 echo ${REFERENCES[@]}
 
 # get digest of the image
-DIGEST=$("${YQ}" eval '.manifests[0].digest' "${IMAGE_DIR}/index.json")
+DIGEST=$("${YQ}" eval -oj -r '.manifests[0].digest' "${IMAGE_DIR}/index.json")
 
 # push the first reference with image digest
 "${CRANE}" push "${IMAGE_DIR}" "${REFERENCES[0]}@${DIGEST}" "${ARGS[@]+"${ARGS[@]}"}"


### PR DESCRIPTION
`yq` will quote the digest string, which will break image pushing.

For example:
```
INFO: Elapsed time: 1.673s, Critical Path: 1.12s
INFO: 5 processes: 1 internal, 4 darwin-sandbox.
INFO: Build completed successfully, 5 total actions
INFO: Running command line: bazel-bin/backend/api/cmd/push_push.sh
europe-west1-docker.pkg.dev/xx/xx
21:48:51 initCommand [WARN] JSON file output is now JSON by default (instead of yaml). Use '-oy' or '--output-format=yaml' for yaml output
Error: could not parse reference: xxxxxx@"sha256:ca70bd1e4c8fada66c93f31c58019ad72dc1f7a6d5a7fa900127e817c87ae679"
```

Remove the warning and unwrap the string.
