### PR TITLE
Revert "refactor: merge repository into repotags (#169)"

### DIFF
--- a/docs/push.md
+++ b/docs/push.md
@@ -7,7 +7,7 @@
 ## oci_push_rule
 
 <pre>
-oci_push_rule(<a href="#oci_push_rule-name">name</a>, <a href="#oci_push_rule-image">image</a>, <a href="#oci_push_rule-repotags">repotags</a>)
+oci_push_rule(<a href="#oci_push_rule-name">name</a>, <a href="#oci_push_rule-image">image</a>, <a href="#oci_push_rule-repository">repository</a>, <a href="#oci_push_rule-repotags">repotags</a>)
 </pre>
 
 Push an oci_image or oci_image_index to a remote registry.
@@ -33,7 +33,8 @@ oci_image(name = "image")
 
 oci_push(
     image = ":image",
-    repotags = ["index.docker.io/<ORG>/image:latest"]
+    repository = "index.docker.io/<ORG>/image",
+    repotags = ["latest"]
 )
 ```
 
@@ -58,17 +59,19 @@ oci_image_index(
 # This is defined in our /examples/push
 stamp_tags(
     name = "stamped",
-    repotags = [""""ghcr.io/<OWNER>/image:"+($stamp.BUILD_EMBED_LABEL // "0.0.0")"""],
+    repotags = ["""($stamp.BUILD_EMBED_LABEL // "0.0.0")"""],
 )
 
 oci_push(
     image = ":app_image",
-    repotags = ":stamped",
+    repository = "ghcr.io/<OWNER>/image",
+    tags = ":stamped",
 )
 ```
 
 When running the pusher, you can pass flags:
-- Additional `repotags`: `-t|--repotag` flag, e.g. `bazel run //myimage:push -- --repotag index.docker.io/<ORG>/image:latest`
+- Override `repository`: `-r|--repository` flag. e.g. `bazel run //myimage:push -- --repository index.docker.io/<ORG>/image`
+- Additional `repotags`: `-t|--tag` flag, e.g. `bazel run //myimage:push -- --tag latest`
 
 
 **ATTRIBUTES**
@@ -78,7 +81,8 @@ When running the pusher, you can pass flags:
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="oci_push_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a id="oci_push_rule-image"></a>image |  Label to an oci_image or oci_image_index   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
-| <a id="oci_push_rule-repotags"></a>repotags |  a file containing repotags, one per line.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| <a id="oci_push_rule-repository"></a>repository |  Repository URL where the image will be signed at, e.g.: <code>index.docker.io/&lt;user&gt;/image</code>.         Digests and tags are not allowed.   | String | required |  |
+| <a id="oci_push_rule-repotags"></a>repotags |  a .txt file containing tags, one per line.         These are passed to [<code>crane tag</code>](         https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_tag.md)   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 
 <a id="#oci_push"></a>

--- a/e2e/auth/BUILD.bazel
+++ b/e2e/auth/BUILD.bazel
@@ -44,5 +44,6 @@ oci_image(
 oci_push(
     name = "push",
     image = ":empty",
-    repotags = [],
+    repository = "localhost/empty_image",
+    repotags = ["latest"],
 )

--- a/e2e/auth/test.bats
+++ b/e2e/auth/test.bats
@@ -17,7 +17,7 @@ function setup_file() {
       sleep 0.1
     done
     
-    bazel run :push -- --repotag localhost:1447/empty_image
+    bazel run :push -- --repository localhost:1447/empty_image
 }
 
 function teardown_file() {

--- a/examples/push/BUILD.bazel
+++ b/examples/push/BUILD.bazel
@@ -11,16 +11,14 @@ oci_image(
 oci_push(
     name = "push_image",
     image = ":image",
-    repotags = [
-        "index.docker.io/<ORG>/image:latest",
-    ],
+    repository = "index.docker.io/<ORG>/image",
+    repotags = ["latest"],
 )
 
 oci_push(
     name = "push_image_wo_tags",
     image = ":image",
-    # left empty to pass at runtime
-    repotags = [],
+    repository = "index.docker.io/<ORG>/image",
 )
 
 oci_image_index(
@@ -34,14 +32,15 @@ stamp_tags(
     name = "stamped",
     repotags = [
         # With --stamp, use the --embed_label value, otherwise use 0.0.0
-        """"index.docker.io/<ORG>/image:"+($stamp.BUILD_EMBED_LABEL // "0.0.0")""",
-        "index.docker.io/<ORG>/image:nightly",
+        """($stamp.BUILD_EMBED_LABEL // "0.0.0")""",
+        "nightly",
     ],
 )
 
 oci_push(
     name = "push_image_index",
     image = ":image_index",
+    repository = "index.docker.io/<ORG>/image",
     repotags = ":stamped",
 )
 

--- a/examples/push/test.bash
+++ b/examples/push/test.bash
@@ -9,34 +9,26 @@ source "${REGISTRY_LAUNCHER}"
 REGISTRY=$(start_registry $TEST_TMPDIR $TEST_TMPDIR/output.log)
 echo "Registry is running at ${REGISTRY}"
 
+
 readonly PUSH_IMAGE="$3"
 readonly PUSH_IMAGE_INDEX="$4"
 readonly PUSH_IMAGE_WO_TAGS="$5"
 
+
 # should push image with default tags
-REPOSITORY="${REGISTRY}/local"
-REPOTAGS_PATH="examples/push/_push_image.tags.txt"
-REPOTAGS="$(cat $REPOTAGS_PATH)"
-REPOTAGS="${REPOTAGS//index.docker.io\/<ORG>\/image/$REPOSITORY}"
-rm "$REPOTAGS_PATH"
-echo "$REPOTAGS" > "$REPOTAGS_PATH"
-"${PUSH_IMAGE}"
+REPOSITORY="${REGISTRY}/local" 
+"${PUSH_IMAGE}" --repository "${REPOSITORY}"
 "${CRANE}" digest "$REPOSITORY:latest"
 
 # should push image_index with default tags
 REPOSITORY="${REGISTRY}/local-index" 
-REPOTAGS_PATH="examples/push/_stamped.tags.txt"
-REPOTAGS="$(cat $REPOTAGS_PATH)"
-REPOTAGS="${REPOTAGS//index.docker.io\/<ORG>\/image/$REPOSITORY}"
-rm "$REPOTAGS_PATH"
-echo "$REPOTAGS" > "$REPOTAGS_PATH"
-"${PUSH_IMAGE_INDEX}"
+"${PUSH_IMAGE_INDEX}" --repository "${REPOSITORY}"
 "${CRANE}" digest "$REPOSITORY:nightly"
 
 
-# should push image without tags
+# should push image without default tags
 REPOSITORY="${REGISTRY}/local-wo-tags" 
-"${PUSH_IMAGE_WO_TAGS}" --repotag "${REPOSITORY}"
+"${PUSH_IMAGE_WO_TAGS}" --repository "${REPOSITORY}"
 TAGS=$("${CRANE}" ls "$REPOSITORY")
 if [ -n "${TAGS}" ]; then 
     echo "image is not supposed to have any tags but got"
@@ -44,9 +36,9 @@ if [ -n "${TAGS}" ]; then
     exit 1
 fi
 
-# should push image with the --repotag flag.
+# should push image with the --tag flag.
 REPOSITORY="${REGISTRY}/local-flag-tag" 
-"${PUSH_IMAGE_WO_TAGS}" --repotag "${REPOSITORY}:custom"
+"${PUSH_IMAGE_WO_TAGS}" --repository "${REPOSITORY}" --tag "custom"
 TAGS=$("${CRANE}" ls "$REPOSITORY")
 if [ "${TAGS}" != "custom" ]; then 
     echo "image is supposed to have custom tag but got"

--- a/oci/private/push.sh.tpl
+++ b/oci/private/push.sh.tpl
@@ -5,44 +5,31 @@ readonly CRANE="{{crane_path}}"
 readonly YQ="{{yq_path}}"
 readonly IMAGE_DIR="{{image_dir}}"
 readonly TAGS_FILE="{{tags}}"
+readonly FIXED_ARGS=({{fixed_args}})
 
-# TODO: should we allow per registry control over insecure registries. It can be enabled with args = ["--insecure"] currently.
-function parse_reference() {
-  local ref=$1
+# set $@ to be FIXED_ARGS+$@
+ALL_ARGS=(${FIXED_ARGS[@]} $@)
+set -- ${ALL_ARGS[@]}
 
-  if [[ "$ref" = *"@"* ]]; then 
-    echo "ERROR: repotags references can not contain digests: $ref"
-    return 1
-  fi
-  
-  # the `%` will remove everything after the last `:`
-  before_colon="${ref%":"*}"
-  colon=${#before_colon}
-  after_colon="${ref:$colon+1}"
-  
-  # it has no tag
-  if [[ $colon -gt 0  && "$after_colon" = *"/"* ]]; then 
-    echo "$ref"
-    echo ""
-    return 0
-  fi
-
-  echo "$before_colon"
-  echo "$after_colon"
-}
-
-REPOTAGS=()
+REPOSITORY="{{repository}}"
+TAGS=()
 ARGS=()
 
-# process flags
 while (( $# > 0 )); do
   case $1 in
-    (-t|--repotag)
-      REPOTAGS+=( "$2" )
+    (-t|--tag)
+      TAGS+=( "$2" )
       shift
       shift;;
-    (--repotag=*) 
-      REPOTAGS+=( "${1#--repotag=}" )
+    (--tag=*) 
+      TAGS+=( "${1#--tag=}" )
+      shift;;
+    (-r|--repository)
+      REPOSITORY="$2"
+      shift
+      shift;;
+    (--repository=*)
+      REPOSITORY="${1#--repository=}"
       shift;;
     (*) 
       ARGS+=( "$1" )
@@ -50,46 +37,16 @@ while (( $# > 0 )); do
   esac
 done
 
-# read repotags file as array and prepend it to REPOTAGS array.
-IFS=$'\n' REPOTAGSFILE=($(cat "$TAGS_FILE"))
-REPOTAGS=(${REPOTAGSFILE[@]+"${REPOTAGSFILE[@]}"} ${REPOTAGS[@]+"${REPOTAGS[@]}"})
-
-if [[ ${#REPOTAGS[@]} -lt 1 ]]; then 
-  echo "ERROR: at least one repotags must be provided."
-  exit 1
-fi 
-
-
-# parse repotags by leaving out tags the and uniqify the result to prevent unnecessary pushes.
-REFERENCES=($(
-  for REPO in "${REPOTAGS[@]+"${REPOTAGS[@]}"}"; do
-    IFS=$'\n' reference=($(parse_reference "$REPO"))
-    echo "${reference[0]}"
-  done | sort -u
-))
-
-echo ${REFERENCES[@]}
-
-# get digest of the image
 DIGEST=$("${YQ}" eval '.manifests[0].digest' "${IMAGE_DIR}/index.json")
 
-# push the first reference with image digest
-"${CRANE}" push "${IMAGE_DIR}" "${REFERENCES[0]}@${DIGEST}" "${ARGS[@]+"${ARGS[@]}"}"
+REFS=$(mktemp)
+"${CRANE}" push "${IMAGE_DIR}" "${REPOSITORY}@${DIGEST}" "${ARGS[@]+"${ARGS[@]}"}" --image-refs "${REFS}"
 
-# copy from first registry to others
-# reason cp is preferred over pushing is cross-repository/registry blob mounting which minimizes network usage if 
-# the registry supports blob mounting. crane will silently fallback to pull&push if the registry misbehaves.
-for REFERENCE in "${REFERENCES[@]:1}"; do 
-  "${CRANE}" cp "${REFERENCES[0]}@${DIGEST}" "${REFERENCE}@${DIGEST}" "${ARGS[@]+"${ARGS[@]}"}"
+for tag in "${TAGS[@]+"${TAGS[@]}"}"
+do
+  "${CRANE}" tag $(cat "${REFS}") "${tag}"
 done
 
-
-# now apply tags to images by digest at their respective registries
-for REPO in "${REPOTAGS[@]+"${REPOTAGS[@]}"}"; do
-  IFS=$'\n' REFERENCE=($(parse_reference "$REPO"))
-  if [[ ${#REFERENCE[@]} -eq 1 ]]; then 
-    continue
-  fi
-  "${CRANE}" tag "${REFERENCE[0]}@$DIGEST" "${REFERENCE[1]}" "${ARGS[@]+"${ARGS[@]}"}"
-done
-  
+if [[ -e "${TAGS_FILE:-}" ]]; then
+  cat "${TAGS_FILE}" | xargs -n1 "${CRANE}" tag $(cat "${REFS}")
+fi


### PR DESCRIPTION
We decided the new API is significantly harder to use, and less intuitive.

This reverts commit 85b695c9b953c3a96d46c116e8fa7af3026588f1.