### PR TITLE
refactor: rename repotags to default_tags

### DIFF
--- a/docs/push.md
+++ b/docs/push.md
@@ -70,8 +70,10 @@ oci_push(
 ```
 
 When running the pusher, you can pass flags:
-- Override `repository`: `-r|--repository` flag. e.g. `bazel run //myimage:push -- --repository index.docker.io/<ORG>/image`
-- Additional `default_tags`: `-t|--tag` flag, e.g. `bazel run //myimage:push -- --tag latest`
+
+- Override `repository`; `-r|--repository` flag. e.g. `bazel run //myimage:push -- --repository index.docker.io/<ORG>/image`
+- Tags in addition to default_tags `default_tags`; `-t|--tag` flag, e.g. `bazel run //myimage:push -- --tag latest`
+
 
 
 **ATTRIBUTES**

--- a/docs/push.md
+++ b/docs/push.md
@@ -104,7 +104,7 @@ Allows the default_tags attribute to be a list of strings in addition to a text 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="oci_push-name"></a>name |  name of resulting oci_push_rule   |  none |
-| <a id="oci_push-default_tags"></a>default_tags |  a list of tags to apply to the image after pushing, or a label of a file containing tags one-per-line. See [stamped_tags](https://github.com/bazel-contrib/rules_oci/blob/main/examples/push/stamp_tags.bzl) as one example of a way to produce such a file.   |  <code>[]</code> |
+| <a id="oci_push-default_tags"></a>default_tags |  a list of tags to apply to the image after pushing, or a label of a file containing tags one-per-line. See [stamped_tags](https://github.com/bazel-contrib/rules_oci/blob/main/examples/push/stamp_tags.bzl) as one example of a way to produce such a file.   |  <code>None</code> |
 | <a id="oci_push-kwargs"></a>kwargs |  other named arguments to [oci_push_rule](#oci_push_rule).   |  none |
 
 

--- a/docs/push.md
+++ b/docs/push.md
@@ -7,7 +7,7 @@
 ## oci_push_rule
 
 <pre>
-oci_push_rule(<a href="#oci_push_rule-name">name</a>, <a href="#oci_push_rule-image">image</a>, <a href="#oci_push_rule-repository">repository</a>, <a href="#oci_push_rule-repotags">repotags</a>)
+oci_push_rule(<a href="#oci_push_rule-name">name</a>, <a href="#oci_push_rule-default_tags">default_tags</a>, <a href="#oci_push_rule-image">image</a>, <a href="#oci_push_rule-repository">repository</a>)
 </pre>
 
 Push an oci_image or oci_image_index to a remote registry.
@@ -20,7 +20,7 @@ Pushing and tagging are performed sequentially which MAY lead to non-atomic push
 - Remote registry closes the connection during the tagging
 - Local network outages
 
-In order to avoid incomplete pushes oci_push will push the image by its digest and then apply the `repotags` sequentially at
+In order to avoid incomplete pushes oci_push will push the image by its digest and then apply the `default_tags` sequentially at
 the remote registry. 
 
 Any failure during pushing or tagging will be reported with non-zero exit code cause remaining steps to be skipped.
@@ -34,7 +34,7 @@ oci_image(name = "image")
 oci_push(
     image = ":image",
     repository = "index.docker.io/<ORG>/image",
-    repotags = ["latest"]
+    default_tags = ["latest"]
 )
 ```
 
@@ -59,7 +59,7 @@ oci_image_index(
 # This is defined in our /examples/push
 stamp_tags(
     name = "stamped",
-    repotags = ["""($stamp.BUILD_EMBED_LABEL // "0.0.0")"""],
+    default_tags = ["""($stamp.BUILD_EMBED_LABEL // "0.0.0")"""],
 )
 
 oci_push(
@@ -71,7 +71,7 @@ oci_push(
 
 When running the pusher, you can pass flags:
 - Override `repository`: `-r|--repository` flag. e.g. `bazel run //myimage:push -- --repository index.docker.io/<ORG>/image`
-- Additional `repotags`: `-t|--tag` flag, e.g. `bazel run //myimage:push -- --tag latest`
+- Additional `default_tags`: `-t|--tag` flag, e.g. `bazel run //myimage:push -- --tag latest`
 
 
 **ATTRIBUTES**
@@ -80,9 +80,9 @@ When running the pusher, you can pass flags:
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="oci_push_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| <a id="oci_push_rule-default_tags"></a>default_tags |  a .txt file containing tags, one per line.         These are passed to [<code>crane tag</code>](         https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_tag.md)   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="oci_push_rule-image"></a>image |  Label to an oci_image or oci_image_index   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 | <a id="oci_push_rule-repository"></a>repository |  Repository URL where the image will be signed at, e.g.: <code>index.docker.io/&lt;user&gt;/image</code>.         Digests and tags are not allowed.   | String | required |  |
-| <a id="oci_push_rule-repotags"></a>repotags |  a .txt file containing tags, one per line.         These are passed to [<code>crane tag</code>](         https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_tag.md)   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 
 <a id="#oci_push"></a>
@@ -90,12 +90,12 @@ When running the pusher, you can pass flags:
 ## oci_push
 
 <pre>
-oci_push(<a href="#oci_push-name">name</a>, <a href="#oci_push-repotags">repotags</a>, <a href="#oci_push-kwargs">kwargs</a>)
+oci_push(<a href="#oci_push-name">name</a>, <a href="#oci_push-default_tags">default_tags</a>, <a href="#oci_push-kwargs">kwargs</a>)
 </pre>
 
 Macro wrapper around [oci_push_rule](#oci_push_rule).
 
-Allows the repotags attribute to be a list of strings in addition to a text file.
+Allows the default_tags attribute to be a list of strings in addition to a text file.
 
 
 **PARAMETERS**
@@ -104,7 +104,7 @@ Allows the repotags attribute to be a list of strings in addition to a text file
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="oci_push-name"></a>name |  name of resulting oci_push_rule   |  none |
-| <a id="oci_push-repotags"></a>repotags |  a list of tags to apply to the image after pushing, or a label of a file containing tags one-per-line. See [stamped_tags](https://github.com/bazel-contrib/rules_oci/blob/main/examples/push/stamp_tags.bzl) as one example of a way to produce such a file.   |  <code>None</code> |
+| <a id="oci_push-default_tags"></a>default_tags |  a list of tags to apply to the image after pushing, or a label of a file containing tags one-per-line. See [stamped_tags](https://github.com/bazel-contrib/rules_oci/blob/main/examples/push/stamp_tags.bzl) as one example of a way to produce such a file.   |  <code>[]</code> |
 | <a id="oci_push-kwargs"></a>kwargs |  other named arguments to [oci_push_rule](#oci_push_rule).   |  none |
 
 

--- a/docs/push.md
+++ b/docs/push.md
@@ -7,7 +7,7 @@
 ## oci_push_rule
 
 <pre>
-oci_push_rule(<a href="#oci_push_rule-name">name</a>, <a href="#oci_push_rule-default_tags">default_tags</a>, <a href="#oci_push_rule-image">image</a>, <a href="#oci_push_rule-repository">repository</a>)
+oci_push_rule(<a href="#oci_push_rule-name">name</a>, <a href="#oci_push_rule-image">image</a>, <a href="#oci_push_rule-remote_tags">remote_tags</a>, <a href="#oci_push_rule-repository">repository</a>)
 </pre>
 
 Push an oci_image or oci_image_index to a remote registry.
@@ -20,7 +20,7 @@ Pushing and tagging are performed sequentially which MAY lead to non-atomic push
 - Remote registry closes the connection during the tagging
 - Local network outages
 
-In order to avoid incomplete pushes oci_push will push the image by its digest and then apply the `default_tags` sequentially at
+In order to avoid incomplete pushes oci_push will push the image by its digest and then apply the `remote_tags` sequentially at
 the remote registry. 
 
 Any failure during pushing or tagging will be reported with non-zero exit code cause remaining steps to be skipped.
@@ -34,7 +34,7 @@ oci_image(name = "image")
 oci_push(
     image = ":image",
     repository = "index.docker.io/<ORG>/image",
-    default_tags = ["latest"]
+    remote_tags = ["latest"]
 )
 ```
 
@@ -59,7 +59,7 @@ oci_image_index(
 # This is defined in our /examples/push
 stamp_tags(
     name = "stamped",
-    default_tags = ["""($stamp.BUILD_EMBED_LABEL // "0.0.0")"""],
+    remote_tags = ["""($stamp.BUILD_EMBED_LABEL // "0.0.0")"""],
 )
 
 oci_push(
@@ -72,7 +72,7 @@ oci_push(
 When running the pusher, you can pass flags:
 
 - Override `repository`; `-r|--repository` flag. e.g. `bazel run //myimage:push -- --repository index.docker.io/<ORG>/image`
-- Tags in addition to default_tags `default_tags`; `-t|--tag` flag, e.g. `bazel run //myimage:push -- --tag latest`
+- Tags in addition to remote_tags `remote_tags`; `-t|--tag` flag, e.g. `bazel run //myimage:push -- --tag latest`
 
 
 
@@ -82,8 +82,8 @@ When running the pusher, you can pass flags:
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="oci_push_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
-| <a id="oci_push_rule-default_tags"></a>default_tags |  a .txt file containing tags, one per line.         These are passed to [<code>crane tag</code>](         https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_tag.md)   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="oci_push_rule-image"></a>image |  Label to an oci_image or oci_image_index   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| <a id="oci_push_rule-remote_tags"></a>remote_tags |  a .txt file containing tags, one per line.         These are passed to [<code>crane tag</code>](         https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_tag.md)   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 | <a id="oci_push_rule-repository"></a>repository |  Repository URL where the image will be signed at, e.g.: <code>index.docker.io/&lt;user&gt;/image</code>.         Digests and tags are not allowed.   | String | required |  |
 
 
@@ -92,12 +92,12 @@ When running the pusher, you can pass flags:
 ## oci_push
 
 <pre>
-oci_push(<a href="#oci_push-name">name</a>, <a href="#oci_push-default_tags">default_tags</a>, <a href="#oci_push-kwargs">kwargs</a>)
+oci_push(<a href="#oci_push-name">name</a>, <a href="#oci_push-remote_tags">remote_tags</a>, <a href="#oci_push-kwargs">kwargs</a>)
 </pre>
 
 Macro wrapper around [oci_push_rule](#oci_push_rule).
 
-Allows the default_tags attribute to be a list of strings in addition to a text file.
+Allows the remote_tags attribute to be a list of strings in addition to a text file.
 
 
 **PARAMETERS**
@@ -106,7 +106,7 @@ Allows the default_tags attribute to be a list of strings in addition to a text 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="oci_push-name"></a>name |  name of resulting oci_push_rule   |  none |
-| <a id="oci_push-default_tags"></a>default_tags |  a list of tags to apply to the image after pushing, or a label of a file containing tags one-per-line. See [stamped_tags](https://github.com/bazel-contrib/rules_oci/blob/main/examples/push/stamp_tags.bzl) as one example of a way to produce such a file.   |  <code>None</code> |
+| <a id="oci_push-remote_tags"></a>remote_tags |  a list of tags to apply to the image after pushing, or a label of a file containing tags one-per-line. See [stamped_tags](https://github.com/bazel-contrib/rules_oci/blob/main/examples/push/stamp_tags.bzl) as one example of a way to produce such a file.   |  <code>None</code> |
 | <a id="oci_push-kwargs"></a>kwargs |  other named arguments to [oci_push_rule](#oci_push_rule).   |  none |
 
 

--- a/e2e/auth/BUILD.bazel
+++ b/e2e/auth/BUILD.bazel
@@ -43,7 +43,7 @@ oci_image(
 
 oci_push(
     name = "push",
+    default_tags = ["latest"],
     image = ":empty",
     repository = "localhost/empty_image",
-    repotags = ["latest"],
 )

--- a/e2e/auth/BUILD.bazel
+++ b/e2e/auth/BUILD.bazel
@@ -43,7 +43,7 @@ oci_image(
 
 oci_push(
     name = "push",
-    default_tags = ["latest"],
     image = ":empty",
+    remote_tags = ["latest"],
     repository = "localhost/empty_image",
 )

--- a/examples/push/BUILD.bazel
+++ b/examples/push/BUILD.bazel
@@ -10,9 +10,9 @@ oci_image(
 
 oci_push(
     name = "push_image",
+    default_tags = ["latest"],
     image = ":image",
     repository = "index.docker.io:9899/<ORG>/image",
-    repotags = ["latest"],
 )
 
 oci_push(
@@ -30,7 +30,7 @@ oci_image_index(
 
 stamp_tags(
     name = "stamped",
-    repotags = [
+    default_tags = [
         # With --stamp, use the --embed_label value, otherwise use 0.0.0
         """($stamp.BUILD_EMBED_LABEL // "0.0.0")""",
         "nightly",
@@ -39,9 +39,9 @@ stamp_tags(
 
 oci_push(
     name = "push_image_index",
+    default_tags = ":stamped",
     image = ":image_index",
     repository = "index.docker.io/<ORG>/image",
-    repotags = ":stamped",
 )
 
 sh_test(

--- a/examples/push/BUILD.bazel
+++ b/examples/push/BUILD.bazel
@@ -10,8 +10,8 @@ oci_image(
 
 oci_push(
     name = "push_image",
-    default_tags = ["latest"],
     image = ":image",
+    remote_tags = ["latest"],
     repository = "index.docker.io:9899/<ORG>/image",
 )
 
@@ -30,7 +30,7 @@ oci_image_index(
 
 stamp_tags(
     name = "stamped",
-    default_tags = [
+    remote_tags = [
         # With --stamp, use the --embed_label value, otherwise use 0.0.0
         """($stamp.BUILD_EMBED_LABEL // "0.0.0")""",
         "nightly",
@@ -39,8 +39,8 @@ stamp_tags(
 
 oci_push(
     name = "push_image_index",
-    default_tags = ":stamped",
     image = ":image_index",
+    remote_tags = ":stamped",
     repository = "index.docker.io/<ORG>/image",
 )
 

--- a/examples/push/stamp_tags.bzl
+++ b/examples/push/stamp_tags.bzl
@@ -3,12 +3,12 @@
 load("@aspect_bazel_lib//lib:jq.bzl", "jq")
 load("@bazel_skylib//lib:types.bzl", "types")
 
-def stamp_tags(name, repotags, **kwargs):
+def stamp_tags(name, default_tags, **kwargs):
     """Wrapper macro around the [jq](https://docs.aspect.build/rules/aspect_bazel_lib/docs/jq) rule.
 
-    Produces a text file that can be used with the `repotags` attribute of [`oci_push`](#oci_push).
+    Produces a text file that can be used with the `default_tags` attribute of [`oci_push`](#oci_push).
 
-    Each entry in `repotags` is typically either a constant like `my-repo:latest`, or can contain a stamp expression.
+    Each entry in `default_tags` is typically either a constant like `my-repo:latest`, or can contain a stamp expression.
     The latter can use any key from `bazel-out/stable-status.txt` or `bazel-out/volatile-status.txt`.
     See https://docs.aspect.build/rules/aspect_bazel_lib/docs/stamping/ for details.
 
@@ -20,11 +20,11 @@ def stamp_tags(name, repotags, **kwargs):
 
     Args:
         name: name of the resulting jq target.
-        repotags: list of jq expressions which result in a string value, see docs above
+        default_tags: list of jq expressions which result in a string value, see docs above
         **kwargs: additional named parameters to the jq rule.
     """
-    if not types.is_list(repotags):
-        fail("repotags should be a list")
+    if not types.is_list(default_tags):
+        fail("default_tags should be a list")
     _maybe_quote = lambda x: x if "\"" in x else "\"{}\"".format(x)
     jq(
         name = name,
@@ -33,7 +33,7 @@ def stamp_tags(name, repotags, **kwargs):
         args = ["--raw-output"],
         filter = "|".join([
             "$ARGS.named.STAMP as $stamp",
-            ",".join([_maybe_quote(t) for t in repotags]),
+            ",".join([_maybe_quote(t) for t in default_tags]),
         ]),
         **kwargs
     )

--- a/examples/push/stamp_tags.bzl
+++ b/examples/push/stamp_tags.bzl
@@ -3,12 +3,12 @@
 load("@aspect_bazel_lib//lib:jq.bzl", "jq")
 load("@bazel_skylib//lib:types.bzl", "types")
 
-def stamp_tags(name, default_tags, **kwargs):
+def stamp_tags(name, remote_tags, **kwargs):
     """Wrapper macro around the [jq](https://docs.aspect.build/rules/aspect_bazel_lib/docs/jq) rule.
 
-    Produces a text file that can be used with the `default_tags` attribute of [`oci_push`](#oci_push).
+    Produces a text file that can be used with the `remote_tags` attribute of [`oci_push`](#oci_push).
 
-    Each entry in `default_tags` is typically either a constant like `my-repo:latest`, or can contain a stamp expression.
+    Each entry in `remote_tags` is typically either a constant like `my-repo:latest`, or can contain a stamp expression.
     The latter can use any key from `bazel-out/stable-status.txt` or `bazel-out/volatile-status.txt`.
     See https://docs.aspect.build/rules/aspect_bazel_lib/docs/stamping/ for details.
 
@@ -20,11 +20,11 @@ def stamp_tags(name, default_tags, **kwargs):
 
     Args:
         name: name of the resulting jq target.
-        default_tags: list of jq expressions which result in a string value, see docs above
+        remote_tags: list of jq expressions which result in a string value, see docs above
         **kwargs: additional named parameters to the jq rule.
     """
-    if not types.is_list(default_tags):
-        fail("default_tags should be a list")
+    if not types.is_list(remote_tags):
+        fail("remote_tags should be a list")
     _maybe_quote = lambda x: x if "\"" in x else "\"{}\"".format(x)
     jq(
         name = name,
@@ -33,7 +33,7 @@ def stamp_tags(name, default_tags, **kwargs):
         args = ["--raw-output"],
         filter = "|".join([
             "$ARGS.named.STAMP as $stamp",
-            ",".join([_maybe_quote(t) for t in default_tags]),
+            ",".join([_maybe_quote(t) for t in remote_tags]),
         ]),
         **kwargs
     )

--- a/oci/defs.bzl
+++ b/oci/defs.bzl
@@ -53,31 +53,31 @@ def oci_image(name, labels = None, annotations = None, **kwargs):
         **kwargs
     )
 
-def oci_push(name, repotags = None, **kwargs):
+def oci_push(name, default_tags = [], **kwargs):
     """Macro wrapper around [oci_push_rule](#oci_push_rule).
 
-    Allows the repotags attribute to be a list of strings in addition to a text file.
+    Allows the default_tags attribute to be a list of strings in addition to a text file.
 
     Args:
         name: name of resulting oci_push_rule
-        repotags: a list of tags to apply to the image after pushing,
+        default_tags: a list of tags to apply to the image after pushing,
             or a label of a file containing tags one-per-line.
             See [stamped_tags](https://github.com/bazel-contrib/rules_oci/blob/main/examples/push/stamp_tags.bzl)
             as one example of a way to produce such a file.
         **kwargs: other named arguments to [oci_push_rule](#oci_push_rule).
     """
-    if types.is_list(repotags):
+    if types.is_list(default_tags):
         tags_label = "_{}_write_tags".format(name)
         write_file(
             name = tags_label,
             out = "_{}.tags.txt".format(name),
-            content = repotags,
+            content = default_tags,
         )
-        repotags = tags_label
+        default_tags = tags_label
 
     oci_push_rule(
         name = name,
-        repotags = repotags,
+        default_tags = default_tags,
         **kwargs
     )
 

--- a/oci/defs.bzl
+++ b/oci/defs.bzl
@@ -53,7 +53,7 @@ def oci_image(name, labels = None, annotations = None, **kwargs):
         **kwargs
     )
 
-def oci_push(name, default_tags = [], **kwargs):
+def oci_push(name, default_tags = None, **kwargs):
     """Macro wrapper around [oci_push_rule](#oci_push_rule).
 
     Allows the default_tags attribute to be a list of strings in addition to a text file.

--- a/oci/defs.bzl
+++ b/oci/defs.bzl
@@ -53,31 +53,31 @@ def oci_image(name, labels = None, annotations = None, **kwargs):
         **kwargs
     )
 
-def oci_push(name, default_tags = None, **kwargs):
+def oci_push(name, remote_tags = None, **kwargs):
     """Macro wrapper around [oci_push_rule](#oci_push_rule).
 
-    Allows the default_tags attribute to be a list of strings in addition to a text file.
+    Allows the remote_tags attribute to be a list of strings in addition to a text file.
 
     Args:
         name: name of resulting oci_push_rule
-        default_tags: a list of tags to apply to the image after pushing,
+        remote_tags: a list of tags to apply to the image after pushing,
             or a label of a file containing tags one-per-line.
             See [stamped_tags](https://github.com/bazel-contrib/rules_oci/blob/main/examples/push/stamp_tags.bzl)
             as one example of a way to produce such a file.
         **kwargs: other named arguments to [oci_push_rule](#oci_push_rule).
     """
-    if types.is_list(default_tags):
+    if types.is_list(remote_tags):
         tags_label = "_{}_write_tags".format(name)
         write_file(
             name = tags_label,
             out = "_{}.tags.txt".format(name),
-            content = default_tags,
+            content = remote_tags,
         )
-        default_tags = tags_label
+        remote_tags = tags_label
 
     oci_push_rule(
         name = name,
-        default_tags = default_tags,
+        remote_tags = remote_tags,
         **kwargs
     )
 

--- a/oci/private/push.bzl
+++ b/oci/private/push.bzl
@@ -62,8 +62,10 @@ oci_push(
 ```
 
 When running the pusher, you can pass flags:
-- Override `repository`: `-r|--repository` flag. e.g. `bazel run //myimage:push -- --repository index.docker.io/<ORG>/image`
-- Additional `default_tags`: `-t|--tag` flag, e.g. `bazel run //myimage:push -- --tag latest`
+
+- Override `repository`; `-r|--repository` flag. e.g. `bazel run //myimage:push -- --repository index.docker.io/<ORG>/image`
+- Tags in addition to default_tags `default_tags`; `-t|--tag` flag, e.g. `bazel run //myimage:push -- --tag latest`
+
 """
 
 _attrs = {


### PR DESCRIPTION
Having `repotags` in both oci_push and oci_tarball is confusing for the users given they have different semantics. 