### PR TITLE
chore: rename repotags to repo_tags

### DIFF
--- a/docs/tarball.md
+++ b/docs/tarball.md
@@ -8,7 +8,7 @@ For example, given an `:image` target, you could write
 oci_tarball(
     name = "tarball",
     image = ":image",
-    repotags = ["my-repository:latest"],
+    repo_tags = ["my-repository:latest"],
 )
 ```
 
@@ -26,7 +26,7 @@ docker run --rm my-repository:latest
 ## oci_tarball
 
 <pre>
-oci_tarball(<a href="#oci_tarball-name">name</a>, <a href="#oci_tarball-image">image</a>, <a href="#oci_tarball-repotags">repotags</a>)
+oci_tarball(<a href="#oci_tarball-name">name</a>, <a href="#oci_tarball-image">image</a>, <a href="#oci_tarball-repo_tags">repo_tags</a>)
 </pre>
 
 Creates tarball from OCI layouts that can be loaded into docker daemon without needing to publish the image first.
@@ -41,6 +41,6 @@ Passing anything other than oci_image to the image attribute will lead to build 
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="oci_tarball-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a id="oci_tarball-image"></a>image |  Label of a directory containing an OCI layout, typically <code>oci_image</code>   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
-| <a id="oci_tarball-repotags"></a>repotags |  a file containing repotags, one per line.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| <a id="oci_tarball-repo_tags"></a>repo_tags |  a file containing repo_tags, one per line.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 

--- a/e2e/crane_as_registry/BUILD.bazel
+++ b/e2e/crane_as_registry/BUILD.bazel
@@ -21,7 +21,7 @@ oci_image(
 oci_tarball(
     name = "tar",
     image = ":image",
-    repotags = [],
+    repo_tags = [],
 )
 
 container_structure_test(

--- a/e2e/smoke/BUILD.bazel
+++ b/e2e/smoke/BUILD.bazel
@@ -28,7 +28,7 @@ tags = [
 oci_tarball(
     name = "tar",
     image = ":image",
-    repotags = tags,
+    repo_tags = tags,
 )
 
 container_structure_test(

--- a/e2e/wasm/BUILD.bazel
+++ b/e2e/wasm/BUILD.bazel
@@ -52,5 +52,5 @@ build_test(
 oci_tarball(
     name = "tarball",
     image = ":image",
-    repotags = ["gcr.io/wasm:latest"],
+    repo_tags = ["gcr.io/wasm:latest"],
 )

--- a/examples/empty_base/BUILD.bazel
+++ b/examples/empty_base/BUILD.bazel
@@ -27,5 +27,5 @@ container_structure_test(
 oci_tarball(
     name = "tarball",
     image = ":image",
-    repotags = ["gcr.io/empty_base:latest"],
+    repo_tags = ["gcr.io/empty_base:latest"],
 )

--- a/oci/defs.bzl
+++ b/oci/defs.bzl
@@ -81,30 +81,30 @@ def oci_push(name, remote_tags = None, **kwargs):
         **kwargs
     )
 
-def oci_tarball(name, repotags = None, **kwargs):
+def oci_tarball(name, repo_tags = None, **kwargs):
     """Macro wrapper around [oci_tarball_rule](#oci_tarball_rule).
 
-    Allows the repotags attribute to be a list of strings in addition to a text file.
+    Allows the repo_tags attribute to be a list of strings in addition to a text file.
 
     Args:
         name: name of resulting oci_tarball_rule
-        repotags: a list of repository:tag to specify when loading the image,
+        repo_tags: a list of repository:tag to specify when loading the image,
             or a label of a file containing tags one-per-line.
             See [stamped_tags](https://github.com/bazel-contrib/rules_oci/blob/main/examples/push/stamp_tags.bzl)
             as one example of a way to produce such a file.
         **kwargs: other named arguments to [oci_tarball_rule](#oci_tarball_rule).
     """
-    if types.is_list(repotags):
+    if types.is_list(repo_tags):
         tags_label = "_{}_write_tags".format(name)
         write_file(
             name = tags_label,
             out = "_{}.tags.txt".format(name),
-            content = repotags,
+            content = repo_tags,
         )
-        repotags = tags_label
+        repo_tags = tags_label
 
     oci_tarball_rule(
         name = name,
-        repotags = repotags,
+        repo_tags = repo_tags,
         **kwargs
     )

--- a/oci/private/tarball.bzl
+++ b/oci/private/tarball.bzl
@@ -6,7 +6,7 @@ For example, given an `:image` target, you could write
 oci_tarball(
     name = "tarball",
     image = ":image",
-    repotags = ["my-repository:latest"],
+    repo_tags = ["my-repository:latest"],
 )
 ```
 
@@ -26,9 +26,9 @@ Passing anything other than oci_image to the image attribute will lead to build 
 
 attrs = {
     "image": attr.label(mandatory = True, allow_single_file = True, doc = "Label of a directory containing an OCI layout, typically `oci_image`"),
-    "repotags": attr.label(
+    "repo_tags": attr.label(
         doc = """\
-            a file containing repotags, one per line.
+            a file containing repo_tags, one per line.
             """,
         allow_single_file = [".txt"],
     ),
@@ -47,8 +47,8 @@ def _tarball_impl(ctx):
         "{{tarball_path}}": tarball.path,
     }
 
-    if ctx.attr.repotags:
-        substitutions["{{tags}}"] = ctx.file.repotags.path
+    if ctx.attr.repo_tags:
+        substitutions["{{tags}}"] = ctx.file.repo_tags.path
 
     ctx.actions.expand_template(
         template = ctx.file._tarball_sh,
@@ -59,7 +59,7 @@ def _tarball_impl(ctx):
 
     ctx.actions.run(
         executable = executable,
-        inputs = [image, ctx.file.repotags],
+        inputs = [image, ctx.file.repo_tags],
         outputs = [tarball],
         tools = [yq_bin],
         mnemonic = "OCITarball",

--- a/oci/private/tarball.sh.tpl
+++ b/oci/private/tarball.sh.tpl
@@ -28,11 +28,11 @@ done
 # TODO: https://github.com/bazel-contrib/rules_oci/issues/212 
 # we can't use \n due to https://github.com/mikefarah/yq/issues/1430 and 
 # we can't update YQ at the moment because structure_test depends on a specific version
-repotags="${REPOTAGS/$'\n'/%}" \
+repo_tags="${REPOTAGS/$'\n'/%}" \
 config="blobs/${CONFIG_DIGEST}" \
 layers="${LAYERS}" \
 "${YQ}" eval \
-        --null-input '.[0] = {"Config": env(config), "RepoTags": "${repotags}" | envsubst | split("%"), "Layers": env(layers) | map( "blobs/" + . + ".tar.gz") }' \
+        --null-input '.[0] = {"Config": env(config), "RepoTags": "${repo_tags}" | envsubst | split("%"), "Layers": env(layers) | map( "blobs/" + . + ".tar.gz") }' \
         --output-format json > "${STAGING_DIR}/manifest.json"
 
 # TODO: https://github.com/bazel-contrib/rules_oci/issues/217


### PR DESCRIPTION
This reflects the CamelCase -> snake_case mapping, since the term in the manifest.json is 'RepoTags'