### PR TITLE
Adapt to new yq version in aspect-build/bazel-lib

### DIFF
--- a/oci/private/push.sh.tpl
+++ b/oci/private/push.sh.tpl
@@ -37,7 +37,7 @@ while (( $# > 0 )); do
   esac
 done
 
-DIGEST=$("${YQ}" eval '.manifests[0].digest' "${IMAGE_DIR}/index.json")
+DIGEST=$("${YQ}" -oy '.manifests[0].digest' "${IMAGE_DIR}/index.json")
 
 REFS=$(mktemp)
 "${CRANE}" push "${IMAGE_DIR}" "${REPOSITORY}@${DIGEST}" "${ARGS[@]+"${ARGS[@]}"}" --image-refs "${REFS}"


### PR DESCRIPTION
`oci_push`does'nt work with the latest aspect-build/bazel-lib because of changes in yq, see https://github.com/aspect-build/bazel-lib/releases/tag/v1.31.0

See also https://github.com/mikefarah/yq/issues/1608