### PR TITLE
chore: remove bzlmod workaround

### DIFF
--- a/.bazelversion
+++ b/.bazelversion
@@ -1,4 +1,4 @@
-6.1.0
+6.2.0
 
 # The first line of this file is used by Bazelisk and Bazel to be sure
 # the right version of Bazel is used to build and test this repo.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,6 @@ jobs:
         bazelversion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions) }}
         folder:
           - .
-          - e2e/auth
           - e2e/custom_registry
           - e2e/wasm
           - e2e/smoke

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,7 @@ jobs:
         bazelversion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions) }}
         folder:
           - .
+          - e2e/auth
           - e2e/custom_registry
           - e2e/wasm
           - e2e/smoke

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ _Need help?_ This ruleset has support provided by https://aspect.dev.
 
 ## Installation
 
-- Bazel 6 with bzlmod: start from <https://registry.bazel.build/modules/rules_oci>
+- Bazel >= 6.2.0 with `--enable_bzlmod`: start from <https://registry.bazel.build/modules/rules_oci>
 - Others: Copy the WORKSPACE snippet into your `WORKSPACE` file from a release: <https://github.com/bazel-contrib/rules_oci/releases>
 
 To use a commit rather than a release, you can point at any SHA of the repo.

--- a/oci/private/pull.bzl
+++ b/oci/private/pull.bzl
@@ -490,9 +490,7 @@ buildozer 'set digest "sha256:{digest}"' 'remove tag' 'remove platforms' {option
             name = rctx.attr.name,
             target_name = rctx.attr.target_name,
             platform_map = {
-                # Workaround bug in Bazel 6.1.0, see
-                # https://github.com/bazel-contrib/rules_oci/issues/221
-                str(k).replace("@@", "@"): v
+                str(k): v
                 for k, v in rctx.attr.platforms.items()
             },
         )


### PR DESCRIPTION
Bazel 6.2.0 contains a fix for https://github.com/bazelbuild/bazel/issues/17655

Fixes #230 