### PR TITLE
Reproduce private pulling issue + poc a fix

### DIFF
--- a/e2e/auth/BUILD.bazel
+++ b/e2e/auth/BUILD.bazel
@@ -39,6 +39,7 @@ oci_image(
     name = "empty",
     architecture = "arm64",
     os = "linux",
+    base = "@empty_image"
 )
 
 oci_push(

--- a/e2e/auth/WORKSPACE
+++ b/e2e/auth/WORKSPACE
@@ -23,8 +23,11 @@ load("@rules_oci//oci:pull.bzl", "oci_pull")
 
 oci_pull(
     name = "empty_image",
-    digest = "sha256:2d4595bbc0fabeb1489b1071f56c26f44a2f495afaa9386ad7d24e7b3d8dfd3e",
-    image = "http://localhost:1447/empty_image",
+    # digest = "sha256:2d4595bbc0fabeb1489b1071f56c26f44a2f495afaa9386ad7d24e7b3d8dfd3e",
+    # image = "http://localhost:1447/empty_image",
+    digest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    registry = "us.gcr.io",
+    repository = "acme-inc/something-private",
 )
 
 ############################################

--- a/oci/private/pull.bzl
+++ b/oci/private/pull.bzl
@@ -95,6 +95,14 @@ def _get_auth(rctx, state, registry):
                 # cache the result so that we don't do this again unnecessarily.
                 state["auth"][registry] = pattern
 
+        # Quick hack that fixes it
+        for host_raw in config["credHelpers"]:
+            host = _strip_host(host_raw)
+            if host == registry:
+                auth_val = config["credHelpers"][host_raw]
+                pattern = _fetch_auth_via_creds_helper(rctx, host_raw, auth_val)
+                # state["auth"][registry] = pattern
+
     return pattern
 
 def _get_token(rctx, state, registry, repository):
@@ -142,6 +150,7 @@ exec "docker-credential-{}" get <<< "$1"
         """.format(helper_name),
     )
     result = rctx.execute([rctx.path(executable), raw_host])
+    print(result.stdout)
     if result.return_code:
         fail("credential helper failed: \nSTDOUT:\n{}\nSTDERR:\n{}".format(result.stdout, result.stderr))
 


### PR DESCRIPTION
Follow-up to https://github.com/bazel-contrib/rules_oci/issues/126#issuecomment-1534052373 

I spent some time exploring to understand if something was wrong on my side or if there was an issue and managed to pull private images with the crude fix that'll find here. 

The code that handles the authentication seems to make assumptions about `~/.docker/config.json` that do not match the structure of that file. 

```
# ~/.docker/config.json 
{
  "auths": {
    "https://index.docker.io/v1/": {}
  },
  "credHelpers": {
    "asia.gcr.io": "gcloud",
    "eu.gcr.io": "gcloud",
    "gcr.io": "gcloud",
    "marketplace.gcr.io": "gcloud",
    "staging-k8s.gcr.io": "gcloud",
    "us-central1-docker.pkg.dev": "gcloud",
    "us.gcr.io": "gcloud"
  },
  "credsStore": "desktop"
}
```

But the original code tries to look for `us.gcr.io` if that's what I set to the `registry` attr on the `oci_pull`. It then takes a look at the `credsStore` which will is set to `desktop` and doesn't know how to find my private image. 

The fix is to instead iterate on the `credHelpers` if we don't find a matching entry under `"auths"`, which I very crudely implemented. 

I have included in my commit the modifications I did to test the code locally, which allowed me to successfully pull the image. 

At this stage, I think it's best for me to reach out, as I don't know what would be the best solution to write a proper e2e test for such a patch. With some guidance, I could implement the fix properly, though I'm totally okay if you want to take over. 