### PR TITLE
fix: implement per registry credential helpers

### DIFF
--- a/oci/private/pull.bzl
+++ b/oci/private/pull.bzl
@@ -501,7 +501,9 @@ buildozer 'set digest "sha256:{digest}"' 'remove tag' 'remove platforms' {option
             name = rctx.attr.name,
             target_name = rctx.attr.target_name,
             platform_map = {
-                str(k): v
+                # Workaround bug in Bazel 6.1.0, see
+                # https://github.com/bazel-contrib/rules_oci/issues/221
+                str(k).replace("@@", "@"): v
                 for k, v in rctx.attr.platforms.items()
             },
         )

--- a/oci/private/pull.bzl
+++ b/oci/private/pull.bzl
@@ -64,6 +64,13 @@ def _get_auth(rctx, state, registry):
     pattern = {}
     config = state["config"]
 
+    if "credHelpers" in config:
+        for host_raw in config["credHelpers"]:
+            host = _strip_host(host_raw)
+            if host == registry:
+                helper_val = config["credHelpers"][host_raw]
+                return  _fetch_auth_via_creds_helper(rctx, host_raw, helper_val)
+
     if "auths" in config:
         for host_raw in config["auths"]:
             host = _strip_host(host_raw)

--- a/oci/private/pull.bzl
+++ b/oci/private/pull.bzl
@@ -64,14 +64,16 @@ def _get_auth(rctx, state, registry):
     pattern = {}
     config = state["config"]
 
+    # first look into per registry credHelpers if it exists
     if "credHelpers" in config:
         for host_raw in config["credHelpers"]:
             host = _strip_host(host_raw)
             if host == registry:
                 helper_val = config["credHelpers"][host_raw]
-                return  _fetch_auth_via_creds_helper(rctx, host_raw, helper_val)
+                pattern = _fetch_auth_via_creds_helper(rctx, host_raw, helper_val)
 
-    if "auths" in config:
+    # if no match for per registry credential helper for the host then look into auths dictionary 
+    if "auths" in config and len(pattern.keys()) == 0:
         for host_raw in config["auths"]:
             host = _strip_host(host_raw)
             if host == registry:
@@ -99,8 +101,8 @@ def _get_auth(rctx, state, registry):
                         "password": auth_val["password"],
                     }
 
-                # cache the result so that we don't do this again unnecessarily.
-                state["auth"][registry] = pattern
+    # cache the result so that we don't do this again unnecessarily.
+    state["auth"][registry] = pattern
 
     return pattern
 
@@ -499,9 +501,7 @@ buildozer 'set digest "sha256:{digest}"' 'remove tag' 'remove platforms' {option
             name = rctx.attr.name,
             target_name = rctx.attr.target_name,
             platform_map = {
-                # Workaround bug in Bazel 6.1.0, see
-                # https://github.com/bazel-contrib/rules_oci/issues/221
-                str(k).replace("@@", "@"): v
+                str(k): v
                 for k, v in rctx.attr.platforms.items()
             },
         )


### PR DESCRIPTION
Tested using `cgr.dev` (Chainguard Images), which configures per-domain credHelpers for authentication.

Update: This appears to be nearly identical to what was proposed in #236 - I'd be happy for either to be merged.
