### PR TITLE
Add auth support for cgr.dev (Chainguard Images)

### DIFF
--- a/fetch.bzl
+++ b/fetch.bzl
@@ -127,3 +127,18 @@ def fetch_images():
         name = "fluxcd_flux",
         image = "docker.io/fluxcd/flux:1.25.4",
     )
+
+    oci_pull(
+        name = "chainguard_static",
+        image = "cgr.dev/chainguard/static",
+        platforms = [
+            "linux/amd64",
+            "linux/arm",
+            "linux/arm64",
+            "linux/ppc64le",
+            "linux/riscv64",
+            "linux/s390x",
+        ],
+        tag = "latest",
+        reproducible = False,
+    )

--- a/oci/private/pull.bzl
+++ b/oci/private/pull.bzl
@@ -49,6 +49,11 @@ _WWW_AUTH = {
         "scope": "repository:{repository}:pull",
         "service": "ghcr.io/token",
     },
+    "cgr.dev": {
+        "realm": "cgr.dev/token",
+        "service": "cgr.dev",
+        "scope": "repository:{repository}:pull",
+    },    
 }
 
 def _strip_host(url):

--- a/oci/tests/BUILD.bazel
+++ b/oci/tests/BUILD.bazel
@@ -8,6 +8,7 @@ IMAGES_TO_TEST = {
     "distroless_java": "gcr.io/distroless/java17@sha256:161a1d97d592b3f1919801578c3a47c8e932071168a96267698f4b669c24c76d",
     "distroless_static_linux_amd64": "gcr.io/distroless/static@sha256:c3c3d0230d487c0ad3a0d87ad03ee02ea2ff0b3dcce91ca06a1019e07de05f12",
     "fluxcd_flux_single": "docker.io/fluxcd/flux:1.25.4",
+    "chainguard_static": "cgr.dev/chainguard/static:latest",    
 }
 
 # Use crane to pull images as a comparison for our oci_pull repository rule


### PR DESCRIPTION
Obsoletes #238 

The Chainguard Images registry (cgr.dev) require a temporary token to be acquired for authentication. Without adding `cgr.dev` to `_WWW_AUTH`, the test fails with:

```log
WARNING: Download from https://cgr.dev/v2/chainguard/static/manifests/latest failed: class com.google.devtools.build.lib.bazel.repository.downloader.UnrecoverableHttpException GET returned 401 Unauthorized
ERROR: An error occurred during the fetch of repository 'chainguard_static':
   Traceback (most recent call last):
	File "/home/t/src/rules_oci/oci/private/pull.bzl", line 477, column 51, in _oci_alias_impl
		manifest, _ = downloader.download_manifest(rctx.attr.identifier, "mf.json")
	File "/home/t/src/rules_oci/oci/private/pull.bzl", line 280, column 74, in lambda
		download_manifest = lambda identifier, output: _download_manifest(rctx, state, identifier, output),
	File "/home/t/src/rules_oci/oci/private/pull.bzl", line 255, column 18, in _download_manifest
		_download(
	File "/home/t/src/rules_oci/oci/private/pull.bzl", line 223, column 23, in _download
		return download_fn(
	File "/home/t/src/rules_oci/oci/private/download.bzl", line 83, column 35, in _download
		command.extend(_auth_to_header(url, auth))
	File "/home/t/src/rules_oci/oci/private/download.bzl", line 9, column 24, in _auth_to_header
		if auth_val["type"] == "pattern":
Error: key "type" not found in dictionary
```
