### PR TITLE
Make sure that the `tars` list contains unique records

### DIFF
--- a/oci/private/pull.bzl
+++ b/oci/private/pull.bzl
@@ -386,7 +386,8 @@ def _oci_pull_impl(rctx):
 
         # TODO: we should avoid eager-download of the layers ("shallow pull")
         downloader.download_blob(layer["digest"], hash)
-        tars.append(hash)
+        if hash not in tars:
+            tars.append(hash)
 
     # To make testing against `crane pull` simple, we take care to produce a byte-for-byte-identical
     # index.json file, which means we can't use jq (it produces a trailing newline) or starlark

--- a/oci/private/tarball.sh.tpl
+++ b/oci/private/tarball.sh.tpl
@@ -22,7 +22,7 @@ mkdir -p $(dirname "${BLOBS_DIR}/${CONFIG_DIGEST}")
 cp "${CONFIG_BLOB_PATH}" "${BLOBS_DIR}/${CONFIG_DIGEST}"
 
 for LAYER in $(${YQ} ".[]" <<< $LAYERS); do 
-    cp "${IMAGE_DIR}/blobs/${LAYER}" "${BLOBS_DIR}/${LAYER}.tar.gz"
+    cp -f "${IMAGE_DIR}/blobs/${LAYER}" "${BLOBS_DIR}/${LAYER}.tar.gz"
 done
 
 # TODO: https://github.com/bazel-contrib/rules_oci/issues/212 


### PR DESCRIPTION
There is no guarantee that the OCI Manifest layers record contains only unique items. For example, layers which contain no change in the docker image FS will always have a same digests. In such a case, `bazel` will complain that `srcs` for `blog` target contains duplicities. Therefore, we need to be sure that there is no such duplicities when creating `tars` list.

Example of error message:

```
ERROR: /beyond/.bazel_cache/external/test_image_single/BUILD.bazel:43:18: Label '@test_image//:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1' is duplicated in the 'srcs' attribute of rule 'blobs'
```