### PR TITLE
Fix failing //oci/tests:test_chainguard_static test on ARM.

### DIFF
--- a/oci/tests/BUILD.bazel
+++ b/oci/tests/BUILD.bazel
@@ -8,7 +8,7 @@ IMAGES_TO_TEST = {
     "distroless_java": "gcr.io/distroless/java17@sha256:161a1d97d592b3f1919801578c3a47c8e932071168a96267698f4b669c24c76d",
     "distroless_static_linux_amd64": "gcr.io/distroless/static@sha256:c3c3d0230d487c0ad3a0d87ad03ee02ea2ff0b3dcce91ca06a1019e07de05f12",
     "fluxcd_flux_single": "docker.io/fluxcd/flux:1.25.4",
-    "chainguard_static": "cgr.dev/chainguard/static:latest",    
+    "chainguard_static_linux_amd64": "cgr.dev/chainguard/static:latest",
 }
 
 # Use crane to pull images as a comparison for our oci_pull repository rule
@@ -17,13 +17,13 @@ IMAGES_TO_TEST = {
         name = "pull_{}".format(repo_name),
         outs = [repo_name],
         cmd = "$(CRANE_BIN) pull {reference} $@ --format=oci --platform={platform}".format(
-            reference = reference,
             platform = _PLATFORM,
+            reference = reference,
         ),
         local = True,  # needs to run locally to able to use credential helpers
         message = "Pulling {reference} for {platform}".format(
-            reference = reference,
             platform = _PLATFORM,
+            reference = reference,
         ),
         output_to_bindir = True,
         tags = ["requires-network"],
@@ -39,7 +39,9 @@ IMAGES_TO_TEST = {
     diff_test(
         name = "test_{}".format(repo_name),
         file1 = repo_name,
-        file2 = "@{}".format(repo_name),
+        file2 = "@{}".format(
+            repo_name,
+        ),
     )
     for repo_name, reference in IMAGES_TO_TEST.items()
 ]


### PR DESCRIPTION
When executed on M1 mac, the diff was failing, as we were comparing alias pointing to ARM (default local platform) vs. crane fetched hardcoded amd.

```
40a3355584e3c9359179972071a/sandbox/darwin-sandbox/208/execroot/rules_oci/bazel-out/darwin_arm64-fastbuild/bin/oci/tests/test_chainguard_static-test.sh.runfiles/chainguard_static_linux_arm64/layout/index.json
8c8
<          "digest": "sha256:fbfb8a6a1edd7e4f714a3bfdd5e5446e0c13af472d629714399e0c3354db2619",
---
>          "digest": "sha256:bbb40acafe3392a2ff85fa23f597caad80ced4ec698f1adc7638f4fb806d78b2",
10c10
<             "architecture": "amd64",
---
>             "architecture": "arm64",
FAIL: directories "oci/tests/chainguard_static" and "external/chainguard_static_linux_arm64/layout" differ.
```