### PR TITLE
fix: Avoid mkdir -p attempting to change permissions

### DIFF
--- a/oci/private/image_index.sh.tpl
+++ b/oci/private/image_index.sh.tpl
@@ -4,6 +4,10 @@ set -o pipefail -o errexit -o nounset
 readonly YQ="{{yq_path}}"
 readonly COREUTILS="{{coreutils_path}}"
 
+function mkdirp() {
+    test -d "$1" || "${COREUTILS}" mkdir -p "$1"
+}
+
 function add_image() {
     local image_path="$1"
     local output_path="$2"
@@ -27,13 +31,13 @@ function copy_blob() {
     local output_path="$2"
     local blob_image_relative_path="$3"
     local dest_path="${output_path}/${blob_image_relative_path}"
-    "${COREUTILS}" mkdir -p "$(dirname "${dest_path}")"
+    mkdirp "$(dirname "${dest_path}")"
     "${COREUTILS}" cat "${image_path}/${blob_image_relative_path}" > "${dest_path}"
 }
 
 function create_oci_layout() {
     local path="$1"
-    "${COREUTILS}" mkdir -p "${path}"
+    mkdirp "${path}"
 
     echo '{"imageLayoutVersion": "1.0.0"}' > "${path}/oci-layout" 
     echo '{"schemaVersion": 2, "manifests": []}' > "${path}/index.json"

--- a/oci/private/image_index.sh.tpl
+++ b/oci/private/image_index.sh.tpl
@@ -4,6 +4,9 @@ set -o pipefail -o errexit -o nounset
 readonly YQ="{{yq_path}}"
 readonly COREUTILS="{{coreutils_path}}"
 
+# Only crete the directory if it doesn't already exist.
+# Otherwise we may attempt to modify permissions of an existing directory.
+# See https://github.com/bazel-contrib/rules_oci/pull/271
 function mkdirp() {
     test -d "$1" || "${COREUTILS}" mkdir -p "$1"
 }


### PR DESCRIPTION
Output directories (`ctx.actions.declare_directory` et al) are created by bazel
before invoking the action.  On 'clever' build executors, they may be symlinks
to other locations or other exotic implementation details.

A naive `mkdir -p` will try to create these directories if they don't exist _and
also_ set dir permissions to what mkdir thinks they should be.  This latter
permissions step can fail in more interesting build environments, even when the
dir already exists and `mkdir -p` should be a no-op.

This PR avoids invoking `mkdir -p` at all if the dir already exists.