### PR TITLE
Fix typo in oci_push docs

### DIFF
--- a/docs/push.md
+++ b/docs/push.md
@@ -71,7 +71,7 @@ stamp_tags(
 oci_push(
     image = ":app_image",
     repository = "ghcr.io/<OWNER>/image",
-    tags = ":stamped",
+    remote_tags = ":stamped",
 )
 ```
 

--- a/oci/private/push.bzl
+++ b/oci/private/push.bzl
@@ -57,7 +57,7 @@ stamp_tags(
 oci_push(
     image = ":app_image",
     repository = "ghcr.io/<OWNER>/image",
-    tags = ":stamped",
+    remote_tags = ":stamped",
 )
 ```
 


### PR DESCRIPTION
I don't believe `tags` is a valid parameter name: https://github.com/bazel-contrib/rules_oci/blob/main/oci/defs.bzl#L62

It also doesn't seem to be a valid parameter of `oci_push_rule`. 