### PR TITLE
Remove '"' from path in MANIFEST_DIGEST when creating a tar file

### DIFF
--- a/oci/private/tarball.sh.tpl
+++ b/oci/private/tarball.sh.tpl
@@ -10,7 +10,7 @@ readonly TAGS_FILE="{{tags}}"
 
 REPOTAGS="$(cat "${TAGS_FILE}")"
 
-MANIFEST_DIGEST=$(${YQ} eval '.manifests[0].digest | sub(":"; "/")' "${IMAGE_DIR}/index.json" | tr '"')
+MANIFEST_DIGEST=$(${YQ} eval '.manifests[0].digest | sub(":"; "/")' "${IMAGE_DIR}/index.json" | tr  -d '"')
 MANIFEST_BLOB_PATH="${IMAGE_DIR}/blobs/${MANIFEST_DIGEST}"
 
 CONFIG_DIGEST=$(${YQ} eval '.config.digest  | sub(":"; "/")' ${MANIFEST_BLOB_PATH})

--- a/oci/private/tarball.sh.tpl
+++ b/oci/private/tarball.sh.tpl
@@ -10,7 +10,7 @@ readonly TAGS_FILE="{{tags}}"
 
 REPOTAGS="$(cat "${TAGS_FILE}")"
 
-MANIFEST_DIGEST=$(${YQ} eval '.manifests[0].digest | sub(":"; "/")' "${IMAGE_DIR}/index.json")
+MANIFEST_DIGEST=$(${YQ} eval '.manifests[0].digest | sub(":"; "/")' "${IMAGE_DIR}/index.json" | tr '"')
 MANIFEST_BLOB_PATH="${IMAGE_DIR}/blobs/${MANIFEST_DIGEST}"
 
 CONFIG_DIGEST=$(${YQ} eval '.config.digest  | sub(":"; "/")' ${MANIFEST_BLOB_PATH})


### PR DESCRIPTION
Fix for this issue: https://github.com/bazel-contrib/rules_oci/issues/273

New version of "yq" will fail processing a path that includes '"'. This fix removes the extra '"' from the path in MANIFEST_DIGEST in the script template that creates the tarball.