### PR TITLE
Fix: Error: key "type" not found in dictionary

### DIFF
--- a/oci/private/download.bzl
+++ b/oci/private/download.bzl
@@ -7,6 +7,9 @@ def _auth_to_header(url, auth):
         if auth_url == url:
             auth_val = auth[auth_url]
 
+            if "type" not in auth_val:
+              continue
+
             if auth_val["type"] == "basic":
                 credentials = base64.encode("{}:{}".format(auth_val["login"], auth_val["password"]))
                 return [


### PR DESCRIPTION
This is as simple fix for #284. It may not solve the root cause, which I do not know what that might be, but it appears to resolve #284.
