### PR TITLE
fix(docs): indicate that oci_tarball#repo_tags is mandatory

### DIFF
--- a/docs/tarball.md
+++ b/docs/tarball.md
@@ -41,6 +41,6 @@ Passing anything other than oci_image to the image attribute will lead to build 
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="oci_tarball-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a id="oci_tarball-image"></a>image |  Label of a directory containing an OCI layout, typically <code>oci_image</code>   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
-| <a id="oci_tarball-repo_tags"></a>repo_tags |  a file containing repo_tags, one per line.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| <a id="oci_tarball-repo_tags"></a>repo_tags |  a file containing repo_tags, one per line.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 
 

--- a/oci/private/tarball.bzl
+++ b/oci/private/tarball.bzl
@@ -31,6 +31,7 @@ attrs = {
             a file containing repo_tags, one per line.
             """,
         allow_single_file = [".txt"],
+        mandatory = True,
     ),
     "_tarball_sh": attr.label(allow_single_file = True, default = "//oci/private:tarball.sh.tpl"),
 }


### PR DESCRIPTION
We always tried to read from the file, so this isn't a breaking change - it already wouldn't have worked

Fixes #272