### PR TITLE
Fix invalid tarball manifest creation

### DIFF
--- a/oci/private/tarball.sh.tpl
+++ b/oci/private/tarball.sh.tpl
@@ -8,8 +8,6 @@ readonly BLOBS_DIR="${STAGING_DIR}/blobs"
 readonly TARBALL_PATH="{{tarball_path}}"
 readonly TAGS_FILE="{{tags}}"
 
-REPOTAGS="$(cat "${TAGS_FILE}")"
-
 MANIFEST_DIGEST=$(${YQ} eval '.manifests[0].digest | sub(":"; "/")' "${IMAGE_DIR}/index.json" | tr  -d '"')
 MANIFEST_BLOB_PATH="${IMAGE_DIR}/blobs/${MANIFEST_DIGEST}"
 
@@ -28,7 +26,7 @@ done
 # TODO: https://github.com/bazel-contrib/rules_oci/issues/212 
 # we can't use \n due to https://github.com/mikefarah/yq/issues/1430 and 
 # we can't update YQ at the moment because structure_test depends on a specific version
-repo_tags="${REPOTAGS/$'\n'/%}" \
+repo_tags="$(tr '\n' '%' < $TAGS_FILE)" \
 config="blobs/${CONFIG_DIGEST}" \
 layers="${LAYERS}" \
 "${YQ}" eval \


### PR DESCRIPTION
Use 'tr' instead of the bash replacements to fix invalid tarballs being created.

I tried writing a test for this but seeing as the bundle script just calls 'docker load' it sort of escapes the test sandbox. I've verified it locally, hopefully it should just sort of 'make sense' at a glance

closes #280