### PR TITLE
fix: oci_tarball should support more than 2 repo_tags

### DIFF
--- a/examples/empty_base/BUILD.bazel
+++ b/examples/empty_base/BUILD.bazel
@@ -27,5 +27,9 @@ container_structure_test(
 oci_tarball(
     name = "tarball",
     image = ":image",
-    repo_tags = ["gcr.io/empty_base:latest"],
+    repo_tags = [
+        "gcr.io/empty_base:latest",
+        "two:is_a_company",
+        "three:is_a_crowd",  # Used to test support for more than two repo_tags.
+    ],
 )

--- a/oci/private/tarball.sh.tpl
+++ b/oci/private/tarball.sh.tpl
@@ -28,7 +28,7 @@ done
 # TODO: https://github.com/bazel-contrib/rules_oci/issues/212 
 # we can't use \n due to https://github.com/mikefarah/yq/issues/1430 and 
 # we can't update YQ at the moment because structure_test depends on a specific version
-repo_tags="${REPOTAGS/$'\n'/%}" \
+repo_tags="${REPOTAGS//$'\n'/%}" \
 config="blobs/${CONFIG_DIGEST}" \
 layers="${LAYERS}" \
 "${YQ}" eval \


### PR DESCRIPTION
Due to usage of 'replace_one' in bash instead of 'replace_all',

the attempts to run `bazel run examples/empty_base/tarball` (with 3 tags), failed with 'Invalid reference format' error, as the line 2 and 3 kept being separated by 'explicit \n'.