### PR TITLE
Ignore empty repo-tags in the file. Allow \n at the end of files.

### DIFF
--- a/examples/repo_tags/BUILD.bazel
+++ b/examples/repo_tags/BUILD.bazel
@@ -1,0 +1,44 @@
+load("//oci:defs.bzl", "oci_image", "oci_tarball")
+load("@aspect_bazel_lib//lib:testing.bzl", "assert_json_matches")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+
+oci_image(
+    name = "image",
+    architecture = select({
+        "@platforms//cpu:arm64": "arm64",
+        "@platforms//cpu:x86_64": "amd64",
+    }),
+    os = "linux",
+)
+
+repo_tags = [
+    "gcr.io/empty_base:latest",
+    "two:is_a_company",
+    "three:is_a_crowd",  # Used to test support for more than two repo_tags.
+]
+
+oci_tarball(
+    name = "tarball",
+    image = ":image",
+    repo_tags = ":tags_file.txt",  # In particular we check whether empty (last line) of the file gets ignored.
+)
+
+genrule(
+    name = "tar_manifest",
+    srcs = [":tarball"],
+    outs = ["manifest.json"],
+    cmd = "tar -xOf ./$(location :tarball) manifest.json > $@",
+)
+
+write_file(
+    name = "expected_RepoTags",
+    out = "expected_RepoTags.json",
+    content = [str(repo_tags)],
+)
+
+assert_json_matches(
+    name = "check_tags",
+    file1 = ":tar_manifest",
+    file2 = ":expected_RepoTags",
+    filter1 = ".[0].RepoTags",
+)

--- a/examples/repo_tags/tags_file.txt
+++ b/examples/repo_tags/tags_file.txt
@@ -1,0 +1,6 @@
+gcr.io/empty_base:latest
+
+
+two:is_a_company
+
+three:is_a_crowd

--- a/examples/repo_tags/test.yaml
+++ b/examples/repo_tags/test.yaml
@@ -1,0 +1,8 @@
+schemaVersion: "2.0.0"
+
+metadataTest:
+  envVars:
+    - key: "ENV"
+      value: "/test"
+  entrypoint: ["/custom_bin"]
+  cmd: ["--arg1", "--arg2"]

--- a/oci/private/tarball.bzl
+++ b/oci/private/tarball.bzl
@@ -6,6 +6,7 @@ For example, given an `:image` target, you could write
 oci_tarball(
     name = "tarball",
     image = ":image",
+    image = ":image",
     repo_tags = ["my-repository:latest"],
 )
 ```

--- a/oci/private/tarball.bzl
+++ b/oci/private/tarball.bzl
@@ -6,7 +6,6 @@ For example, given an `:image` target, you could write
 oci_tarball(
     name = "tarball",
     image = ":image",
-    image = ":image",
     repo_tags = ["my-repository:latest"],
 )
 ```

--- a/oci/private/tarball.sh.tpl
+++ b/oci/private/tarball.sh.tpl
@@ -32,7 +32,7 @@ done
 repo_tags="${REPOTAGS}" \
 config="blobs/${CONFIG_DIGEST}" \
 layers="${LAYERS}" \
-"${YQ}" -v eval \
+"${YQ}" eval \
         --null-input '.[0] = {"Config": env(config), "RepoTags": "${repo_tags}" | envsubst | split("%") | map(select(. != "")) , "Layers": env(layers) | map( "blobs/" + . + ".tar.gz") }' \
         --output-format json > "${STAGING_DIR}/manifest.json"
 

--- a/oci/private/tarball.sh.tpl
+++ b/oci/private/tarball.sh.tpl
@@ -32,8 +32,8 @@ done
 repo_tags="${REPOTAGS}" \
 config="blobs/${CONFIG_DIGEST}" \
 layers="${LAYERS}" \
-"${YQ}" eval \
-        --null-input '.[0] = {"Config": env(config), "RepoTags": "${repo_tags}" | envsubst | split("%"), "Layers": env(layers) | map( "blobs/" + . + ".tar.gz") }' \
+"${YQ}" -v eval \
+        --null-input '.[0] = {"Config": env(config), "RepoTags": "${repo_tags}" | envsubst | split("%") | map(select(. != "")) , "Layers": env(layers) | map( "blobs/" + . + ".tar.gz") }' \
         --output-format json > "${STAGING_DIR}/manifest.json"
 
 # TODO: https://github.com/bazel-contrib/rules_oci/issues/217


### PR DESCRIPTION
In particular without the change, a file with a trailing '\n' in the last line (expected) was considered to generate a new empty repo-tag.