### PR TITLE
fix: restrict oci_image#tar attribute to .tar files

### DIFF
--- a/examples/deb/BUILD.bazel
+++ b/examples/deb/BUILD.bazel
@@ -1,14 +1,33 @@
-load("//oci:defs.bzl", "oci_image")
+load("//oci:defs.bzl", "oci_image", "oci_tarball")
+
+_ARCH = [
+    "amd64",
+    "arm64",
+]
+
+# crane doesn't do the right thing with compressed tarball inputs like .tar.gz or .tar.xz
+[
+    genrule(
+        name = "decompress_" + architecture,
+        srcs = ["@bash_{}//:layer".format(architecture)],
+        outs = ["_{}.tar".format(architecture)],
+        cmd = "xz --decompress --stdout $< >$@",
+    )
+    for architecture in _ARCH
+]
 
 [
     oci_image(
         name = "image_" + architecture,
         architecture = architecture,
         os = "linux",
-        tars = ["@bash_{}//:layer".format(architecture)],
+        tars = ["_{}.tar".format(architecture)],
     )
-    for architecture in [
-        "amd64",
-        "arm64",
-    ]
+    for architecture in _ARCH
 ]
+
+oci_tarball(
+    name = "tarball",
+    image = ":image_amd64",
+    repo_tags = ["test:test"],
+)

--- a/oci/private/image.bzl
+++ b/oci/private/image.bzl
@@ -51,7 +51,7 @@ oci_image(
 """
 _attrs = {
     "base": attr.label(allow_single_file = True, doc = "Label to an oci_image target to use as the base."),
-    "tars": attr.label_list(allow_files = [".tar", ".tar.gz", ".tar.xz"], doc = """\
+    "tars": attr.label_list(allow_files = [".tar"], doc = """\
         List of tar files to add to the image as layers.
         Do not sort this list; the order is preserved in the resulting image.
         Less-frequently changed files belong in lower layers to reduce the network bandwidth required to pull and push.


### PR DESCRIPTION
See explanation in #302. Non-tar files never actually worked here.

Fixes #302