### PR TITLE
fix: allow passwords that contain  :

### DIFF
--- a/oci/private/pull.bzl
+++ b/oci/private/pull.bzl
@@ -91,7 +91,9 @@ def _get_auth(rctx, state, registry):
                 elif "auth" in auth_val:
                     # base64 encoded plaintext username and password
                     raw_auth = auth_val["auth"]
-                    (login, password) = base64.decode(raw_auth).split(":", 1)
+                    login, sep, password = base64.decode(raw_auth).partition(":")
+                    if not sep:
+                        fail("Auth string must be in form username:password")
                     pattern = {
                         "type": "basic",
                         "login": login,

--- a/oci/private/pull.bzl
+++ b/oci/private/pull.bzl
@@ -93,7 +93,7 @@ def _get_auth(rctx, state, registry):
                     raw_auth = auth_val["auth"]
                     login, sep, password = base64.decode(raw_auth).partition(":")
                     if not sep:
-                        fail("Auth string must be in form username:password")
+                        fail("auth string must be in form username:password")
                     pattern = {
                         "type": "basic",
                         "login": login,

--- a/oci/private/pull.bzl
+++ b/oci/private/pull.bzl
@@ -91,7 +91,7 @@ def _get_auth(rctx, state, registry):
                 elif "auth" in auth_val:
                     # base64 encoded plaintext username and password
                     raw_auth = auth_val["auth"]
-                    (login, password) = base64.decode(raw_auth).split(":")
+                    (login, password) = base64.decode(raw_auth).split(":", 1)
                     pattern = {
                         "type": "basic",
                         "login": login,


### PR DESCRIPTION
The way auth is currently splitting username:password does not work if the password contains colons(:). Such is the case when authenticating against the Google Artifact Registry using a Service Account.  Allowing a maximum of 1 splits will make it work.