### PR TITLE
fix harbor MANIFEST_UNKNOWN error when pulling OCI manifests

### DIFF
--- a/oci/private/pull.bzl
+++ b/oci/private/pull.bzl
@@ -236,7 +236,10 @@ def _download_manifest(rctx, state, identifier, output):
     bytes = None
     manifest = None
 
-    result = _download(rctx, state, identifier, output, "manifests", allow_fail = True)
+    headers = {
+        "Accept": ", ".join(_SUPPORTED_MEDIA_TYPES["manifest"]),
+    }
+    result = _download(rctx, state, identifier, output, "manifests", headers = headers, allow_fail = True)
     fallback_to_curl = False
 
     if result.success:


### PR DESCRIPTION
If Accept header is not set properly, harbor container registry throws MANIFEST_UNKNOWN when try pulling OCI image manifests.

Which will returns user a WARNING:
```
WARNING: Could not fetch the manifest. Either there was an authentication issue or trying to pull an image with OCI image media types. 
```

And then failed using curl:
```
WARNING: Download from https://build-harbor.alauda.cn/v2/sync/distroless/static/manifests/sha256:852f29111d13f029b1405b0cdffebb304d012ebfed679593574830106878c58e failed: class java.io.FileNotFoundException GET returned 404 Not Found
```

For example:
```json
{"errors":[{"code":"MANIFEST_UNKNOWN","message":"OCI manifest found, but accept header does not support OCI manifests"}]}
```