### PR TITLE
fix(oci_image): restore tars=foo.tar.gz

### DIFF
--- a/examples/deb/BUILD.bazel
+++ b/examples/deb/BUILD.bazel
@@ -5,7 +5,8 @@ _ARCH = [
     "arm64",
 ]
 
-# crane doesn't do the right thing with compressed tarball inputs like .tar.gz or .tar.xz
+# Workaround: crane doesn't do the right thing with .tar.xz compression
+# so we simply decompress explicitly first.
 [
     genrule(
         name = "decompress_" + architecture,

--- a/oci/private/image.bzl
+++ b/oci/private/image.bzl
@@ -51,7 +51,7 @@ oci_image(
 """
 _attrs = {
     "base": attr.label(allow_single_file = True, doc = "Label to an oci_image target to use as the base."),
-    "tars": attr.label_list(allow_files = [".tar"], doc = """\
+    "tars": attr.label_list(allow_files = [".tar", ".tar.gz"], doc = """\
         List of tar files to add to the image as layers.
         Do not sort this list; the order is preserved in the resulting image.
         Less-frequently changed files belong in lower layers to reduce the network bandwidth required to pull and push.


### PR DESCRIPTION
Partial revert of #313 which went too far in trimming the allow_files extensions.

Fixes #334