### PR TITLE
Allow passing repository for oci_push in from a file

### DIFF
--- a/docs/push.md
+++ b/docs/push.md
@@ -13,7 +13,7 @@ load("@rules_oci//oci:defs.bzl", ...)
 ## oci_push_rule
 
 <pre>
-oci_push_rule(<a href="#oci_push_rule-name">name</a>, <a href="#oci_push_rule-image">image</a>, <a href="#oci_push_rule-remote_tags">remote_tags</a>, <a href="#oci_push_rule-repository">repository</a>)
+oci_push_rule(<a href="#oci_push_rule-name">name</a>, <a href="#oci_push_rule-image">image</a>, <a href="#oci_push_rule-remote_tags">remote_tags</a>, <a href="#oci_push_rule-repository">repository</a>, <a href="#oci_push_rule-repository_file">repository_file</a>)
 </pre>
 
 Push an oci_image or oci_image_index to a remote registry.
@@ -90,7 +90,8 @@ When running the pusher, you can pass flags:
 | <a id="oci_push_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a id="oci_push_rule-image"></a>image |  Label to an oci_image or oci_image_index   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 | <a id="oci_push_rule-remote_tags"></a>remote_tags |  a .txt file containing tags, one per line.         These are passed to [<code>crane tag</code>](         https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_tag.md)   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
-| <a id="oci_push_rule-repository"></a>repository |  Repository URL where the image will be signed at, e.g.: <code>index.docker.io/&lt;user&gt;/image</code>.         Digests and tags are not allowed.   | String | required |  |
+| <a id="oci_push_rule-repository"></a>repository |  Repository URL where the image will be signed at, e.g.: <code>index.docker.io/&lt;user&gt;/image</code>.         Digests and tags are not allowed.   | String | optional | "" |
+| <a id="oci_push_rule-repository_file"></a>repository_file |  The same as 'repository' but in a file. This allows pushing to different repositories based on stamping.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
 
 
 <a id="#oci_push"></a>

--- a/examples/push/BUILD.bazel
+++ b/examples/push/BUILD.bazel
@@ -16,6 +16,13 @@ oci_push(
 )
 
 oci_push(
+    name = "push_image_repository_file",
+    image = ":image",
+    remote_tags = ["latest"],
+    repository_file = ":repository.txt",
+)
+
+oci_push(
     name = "push_image_wo_tags",
     image = ":image",
     repository = "index.docker.io/<ORG>/image",
@@ -52,11 +59,13 @@ sh_test(
         "$(LAUNCHER_WRAPPER)",
         "$(location :push_image)",
         "$(location :push_image_index)",
+        "$(location :push_image_repository_file)",
         "$(location :push_image_wo_tags)",
     ],
     data = [
         ":push_image",
         ":push_image_index",
+        ":push_image_repository_file",
         ":push_image_wo_tags",
         "@oci_crane_toolchains//:current_toolchain",
         "@oci_zot_toolchains//:current_toolchain",

--- a/examples/push/repository.txt
+++ b/examples/push/repository.txt
@@ -1,0 +1,1 @@
+index.docker.io/<ORG>/image

--- a/examples/push/test.bash
+++ b/examples/push/test.bash
@@ -12,7 +12,8 @@ echo "Registry is running at ${REGISTRY}"
 
 readonly PUSH_IMAGE="$3"
 readonly PUSH_IMAGE_INDEX="$4"
-readonly PUSH_IMAGE_WO_TAGS="$5"
+readonly PUSH_IMAGE_REPOSITORY_FILE="$5"
+readonly PUSH_IMAGE_WO_TAGS="$6"
 
 
 # should push image with default tags
@@ -35,6 +36,14 @@ if [ -n "${TAGS}" ]; then
     echo "${TAGS}"
     exit 1
 fi
+
+
+# should push image to the repository defined in the file
+set -ex
+REPOSITORY="${REGISTRY}/repository-file"
+"${PUSH_IMAGE_REPOSITORY_FILE}" --repository "${REPOSITORY}"
+"${CRANE}" digest "$REPOSITORY:latest"
+
 
 # should push image with the --tag flag.
 REPOSITORY="${REGISTRY}/local-flag-tag" 

--- a/oci/private/push.sh.tpl
+++ b/oci/private/push.sh.tpl
@@ -6,12 +6,17 @@ readonly YQ="{{yq_path}}"
 readonly IMAGE_DIR="{{image_dir}}"
 readonly TAGS_FILE="{{tags}}"
 readonly FIXED_ARGS=({{fixed_args}})
+readonly REPOSITORY_FILE="{{repository_file}}"
+
+REPOSITORY=""
+if [ -f $REPOSITORY_FILE ] ; then
+  REPOSITORY=$(tr -d '\n' < "$REPOSITORY_FILE")
+fi
 
 # set $@ to be FIXED_ARGS+$@
 ALL_ARGS=(${FIXED_ARGS[@]} $@)
 set -- ${ALL_ARGS[@]}
 
-REPOSITORY="{{repository}}"
 TAGS=()
 ARGS=()
 


### PR DESCRIPTION
As mentioned in the updated docs this is useful if you want to push to a different repository (eg, separate dev/prod repositories) based on a stamp variable.