### PR TITLE
Add `toolchain` param to the affected actions

### DIFF
--- a/oci/private/image.bzl
+++ b/oci/private/image.bzl
@@ -194,6 +194,7 @@ def _oci_image_impl(ctx):
         tools = [crane.crane_info.binary, registry.registry_info.launcher, registry.registry_info.registry, jq.jqinfo.bin],
         mnemonic = "OCIImage",
         progress_message = "OCI Image %{label}",
+        toolchain = None,
     )
 
     return [

--- a/oci/private/image_index.bzl
+++ b/oci/private/image_index.bzl
@@ -67,6 +67,7 @@ def _oci_image_index_impl(ctx):
         executable = launcher,
         tools = [yq.yqinfo.bin, coreutils.coreutils_info.bin],
         progress_message = "OCI Index %{label}",
+        toolchain = None,
     )
 
     return DefaultInfo(files = depset([output]))

--- a/oci/private/tarball.bzl
+++ b/oci/private/tarball.bzl
@@ -75,6 +75,7 @@ def _tarball_impl(ctx):
         tools = [yq_bin],
         mnemonic = "OCITarball",
         progress_message = "OCI Tarball %{label}",
+        toolchain = None,
     )
 
     exe = ctx.actions.declare_file(ctx.label.name + ".sh")


### PR DESCRIPTION
This is a step forward for the migration of Automatic Exec Groups. These actions don't use an executable/tool from a toolchain. Hence, `None` should be set.