### PR TITLE
fix: propagate tags for macros in `defs.bzl`

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -90,7 +90,7 @@ oci_image(
 ## oci_image
 
 <pre>
-oci_image(<a href="#oci_image-name">name</a>, <a href="#oci_image-labels">labels</a>, <a href="#oci_image-annotations">annotations</a>, <a href="#oci_image-env">env</a>, <a href="#oci_image-cmd">cmd</a>, <a href="#oci_image-entrypoint">entrypoint</a>, <a href="#oci_image-kwargs">kwargs</a>)
+oci_image(<a href="#oci_image-name">name</a>, <a href="#oci_image-labels">labels</a>, <a href="#oci_image-annotations">annotations</a>, <a href="#oci_image-env">env</a>, <a href="#oci_image-cmd">cmd</a>, <a href="#oci_image-entrypoint">entrypoint</a>, <a href="#oci_image-tags">tags</a>, <a href="#oci_image-kwargs">kwargs</a>)
 </pre>
 
 Macro wrapper around [oci_image_rule](#oci_image_rule).
@@ -118,6 +118,7 @@ This is similar to the same-named target created by rules_docker's `container_im
 | <a id="oci_image-env"></a>env |  Environment variables provisioned by default to the running container. See documentation above.   |  <code>None</code> |
 | <a id="oci_image-cmd"></a>cmd |  Command & argument configured by default in the running container. See documentation above.   |  <code>None</code> |
 | <a id="oci_image-entrypoint"></a>entrypoint |  Entrypoint configured by default in the running container. See documentation above.   |  <code>None</code> |
+| <a id="oci_image-tags"></a>tags |  Tags to propagate to targets declared by this macro. Input will be filtered to well known tags only. See [propagate_well_known_tags] (https://github.com/aspect-build/bazel-lib/blob/main/docs/utils.md#propagate_well_known_tags) for details.   |  <code>[]</code> |
 | <a id="oci_image-kwargs"></a>kwargs |  other named arguments to [oci_image_rule](#oci_image_rule)   |  none |
 
 

--- a/docs/push.md
+++ b/docs/push.md
@@ -98,7 +98,7 @@ When running the pusher, you can pass flags:
 ## oci_push
 
 <pre>
-oci_push(<a href="#oci_push-name">name</a>, <a href="#oci_push-remote_tags">remote_tags</a>, <a href="#oci_push-kwargs">kwargs</a>)
+oci_push(<a href="#oci_push-name">name</a>, <a href="#oci_push-remote_tags">remote_tags</a>, <a href="#oci_push-tags">tags</a>, <a href="#oci_push-kwargs">kwargs</a>)
 </pre>
 
 Macro wrapper around [oci_push_rule](#oci_push_rule).
@@ -113,6 +113,7 @@ Allows the remote_tags attribute to be a list of strings in addition to a text f
 | :------------- | :------------- | :------------- |
 | <a id="oci_push-name"></a>name |  name of resulting oci_push_rule   |  none |
 | <a id="oci_push-remote_tags"></a>remote_tags |  a list of tags to apply to the image after pushing, or a label of a file containing tags one-per-line. See [stamped_tags](https://github.com/bazel-contrib/rules_oci/blob/main/examples/push/stamp_tags.bzl) as one example of a way to produce such a file.   |  <code>None</code> |
+| <a id="oci_push-tags"></a>tags |  Tags to propagate to targets declared by this macro. Input will be filtered to well known tags only. See [propagate_well_known_tags] (https://github.com/aspect-build/bazel-lib/blob/main/docs/utils.md#propagate_well_known_tags) for details.   |  <code>[]</code> |
 | <a id="oci_push-kwargs"></a>kwargs |  other named arguments to [oci_push_rule](#oci_push_rule).   |  none |
 
 

--- a/oci/private/download.bzl
+++ b/oci/private/download.bzl
@@ -124,7 +124,7 @@ def _download(
         if allow_fail:
             return struct(success = False)
         else:
-            fail("curl {} returned non-success status code {}".format(url, status_code))
+            fail("curl returned non-success status code {}. Full command:\n{}".format(status_code, command))
 
     cache_it = rctx.download(
         url = "file://{}".format(output_path),

--- a/oci/private/download.bzl
+++ b/oci/private/download.bzl
@@ -124,7 +124,7 @@ def _download(
         if allow_fail:
             return struct(success = False)
         else:
-            fail("curl returned non-success status code {}. Full command:\n{}".format(status_code, command))
+            fail("curl {} returned non-success status code {}".format(url, status_code))
 
     cache_it = rctx.download(
         url = "file://{}".format(output_path),


### PR DESCRIPTION
Tags were not being propagated to targets declared by the macros in `defs.bzl`. This fixes that by using [propagate_well_known_tags](https://github.com/aspect-build/bazel-lib/blob/main/docs/utils.md#propagate_well_known_tags) to propagate a relevant subset of tags to all targets.