### PR TITLE
fix: remove tag argument from crane image mutate call

### DIFF
--- a/oci/private/image.bzl
+++ b/oci/private/image.bzl
@@ -134,8 +134,6 @@ def _oci_image_impl(ctx):
     args.add_all([
         "mutate",
         base,
-        "--tag",
-        "oci:registry/{}".format(ctx.label.name),
     ])
 
     # add platform


### PR DESCRIPTION
This argument is not providing a useful purpose and breaks when oci_image targets have a capital letter in their name. Removing this does not break the image build since the ref used between the mutate and pull is sourced directly from the output of crane

Closes #351 

Within the image.sh script, this slightly changes the value of the `$REF` variable used from the initial mutate call. Prior to this change, these look like:

`127.0.0.1:42477/<target name>@sha256:<some sha hash>`

Now these inherit the source name for the mutation and look like:

`127.0.0.1:42477/oci/layout@sha256:<some sha hash>` or `127.0.0.1:42477/oci/empty_base@sha256:<some sha hash>`

If you would prefer, the alternate fix is to use a static sentinel value for tag (e.g. `--tag oci:registry/target`), which produces refs like so:

`127.0.0.1:42477/target@sha256:<some sha hash>`

The final output is the same regardless of the value of `$REF` used internally
