### PR TITLE
fix: digest output should include algo

### DIFF
--- a/oci/defs.bzl
+++ b/oci/defs.bzl
@@ -96,7 +96,7 @@ def oci_image(name, labels = None, annotations = None, env = None, **kwargs):
         name = name + ".digest",
         args = ["--raw-output"],
         srcs = ["_{}_index.json".format(name)],
-        filter = """.manifests[0].digest | sub("^sha256:"; "")""",
+        filter = """.manifests[0].digest""",
         out = name + ".json.sha256",  # path chosen to match rules_docker for easy migration
     )
 


### PR DESCRIPTION
Hashes should generally be prefixed with the hash algorithm used. Also, the intent of adding .digest in #346 was to make the migration from rules_docker easier, so we should match its output, as shown https://github.com/bazelbuild/rules_docker/blob/master/tests/container/BUILD#L248-L251

Note, this is not a breaking change, because the commit from #346 was not yet released.