### PR TITLE
feat: add Gitlab Container Registry oci_pull support

### DIFF
--- a/fetch.bzl
+++ b/fetch.bzl
@@ -144,6 +144,13 @@ def fetch_images():
         reproducible = False,
     )
 
+    oci_pull(
+        name = "gitlab_assets_ce",
+        # tag = "v15-11-0-ee",
+        image = "registry.gitlab.com/gitlab-org/gitlab/gitlab-assets-ce",
+        digest = "sha256:78fc30603a49cdabba4cd1c3a94f71cb78e606a98b5b17c690c781c5c8955f29",
+    )
+
     _DEB_TO_LAYER = """\
 alias(
     name = "layer",

--- a/oci/private/pull.bzl
+++ b/oci/private/pull.bzl
@@ -59,6 +59,11 @@ _WWW_AUTH = {
         "scope": "repository:{repository}:pull",
         "service": "{registry}",
     },
+    "registry.gitlab.com": {
+        "realm": "gitlab.com/jwt/auth",
+        "scope": "repository:{repository}:pull",
+        "service": "container_registry",
+    },
 }
 
 def _strip_host(url):

--- a/oci/tests/BUILD.bazel
+++ b/oci/tests/BUILD.bazel
@@ -54,6 +54,7 @@ build_test(
         "@debian",
         "@debian_latest",
         "@debian_stable",
+        "@gitlab_assets_ce",
         # TODO: https://github.com/bazel-contrib/rules_oci/issues/193
         # "@apollo_router",
         "@from_rules_docker",


### PR DESCRIPTION
This adds www-authenticate information for registry.gitlab.com.
