### PR TITLE
Draft: feat: oci_bundle

### DIFF
--- a/examples/bundle/BUILD.bazel
+++ b/examples/bundle/BUILD.bazel
@@ -1,0 +1,48 @@
+load("//oci:defs.bzl", "oci_bundle", "oci_image", "oci_tarball")
+load("@aspect_bazel_lib//lib:testing.bzl", "assert_json_matches")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@container_structure_test//:defs.bzl", "container_structure_test")
+
+oci_image(
+    name = "image_arm64",
+    architecture = "arm64",
+    entrypoint = ["/custom_bin"],
+    os = "linux",
+)
+
+oci_image(
+    name = "image_amd64",
+    architecture = "amd64",
+    entrypoint = ["/custom_bin"],
+    os = "linux",
+)
+
+images = {
+    "app:arm64": ":image_arm64",
+    "app:amd64": ":image_amd64",
+}
+
+oci_bundle(
+    name = "bundle",
+    images = images,
+)
+
+genrule(
+    name = "bundle_manifest",
+    srcs = [":bundle"],
+    outs = ["index.json"],
+    cmd = "cp -f $</index.json $@",
+)
+
+write_file(
+    name = "expected_refs",
+    out = "expected_refs.json",
+    content = [str(images.keys())],
+)
+
+assert_json_matches(
+    name = "check_refs",
+    file1 = ":bundle_manifest",
+    file2 = ":expected_refs",
+    filter1 = "[.manifests[].annotations[\"org.opencontainers.image.ref.name\"]]",
+)

--- a/examples/bundle/test.yaml
+++ b/examples/bundle/test.yaml
@@ -1,0 +1,8 @@
+schemaVersion: "2.0.0"
+
+metadataTest:
+  envVars:
+    - key: "ENV"
+      value: "/test"
+  entrypoint: ["/custom_bin"]
+  cmd: ["--arg1", "--arg2"]

--- a/oci/defs.bzl
+++ b/oci/defs.bzl
@@ -10,6 +10,7 @@ load("//oci/private:tarball.bzl", _oci_tarball = "oci_tarball")
 load("//oci/private:image.bzl", _oci_image = "oci_image")
 load("//oci/private:image_index.bzl", _oci_image_index = "oci_image_index")
 load("//oci/private:push.bzl", _oci_push = "oci_push")
+load("//oci/private:bundle.bzl", _oci_bundle = "oci_bundle")
 load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@aspect_bazel_lib//lib:directory_path.bzl", "directory_path")
 load("@aspect_bazel_lib//lib:jq.bzl", "jq")
@@ -21,6 +22,7 @@ oci_tarball_rule = _oci_tarball
 oci_image_rule = _oci_image
 oci_image_index = _oci_image_index
 oci_push_rule = _oci_push
+oci_bundle_rule = _oci_bundle
 
 def oci_image(name, labels = None, annotations = None, env = None, cmd = None, entrypoint = None, tags = [], **kwargs):
     """Macro wrapper around [oci_image_rule](#oci_image_rule).
@@ -211,5 +213,23 @@ def oci_tarball(name, repo_tags = None, tags = [], **kwargs):
         name = name,
         repo_tags = repo_tags,
         tags = propagate_well_known_tags(tags),
+        **kwargs
+    )
+
+def oci_bundle(name, images = {}, **kwargs):
+    """Macro wrapper around [oci_bundle_rule](#oci_bundle_rule).
+
+    Allows the images attribute to be a string keyed label dict.
+
+    Args:
+        name: name of resulting oci_bundle_rule
+        images: a reference to image dict.
+        **kwargs: other named arguments to [oci_tarball_rule](#oci_tarball_rule).
+    """
+
+    oci_bundle_rule(
+        name = name,
+        image_refs = images.keys(),
+        image_targets = images.values(),
         **kwargs
     )

--- a/oci/private/bundle.bzl
+++ b/oci/private/bundle.bzl
@@ -1,0 +1,97 @@
+"Implementation details for oci rule"
+
+_DOC = """Build a OCI compatible container image bundle.
+
+It takes number of `oci_image/oci_image_index/oci_bundle`s to create a image bundle.
+
+```starlark
+oci_image(
+    name = "app1_linux_amd64"
+)
+
+oci_image(
+    name = "app1_linux_arm64"
+)
+
+oci_bundle(
+    name = "app1",
+    images = [
+        ":app1_linux_amd64",
+        ":app1_linux_arm64"
+    ]
+)
+
+oci_image(
+    name = "app2",
+)
+
+oci_bundle(
+    name = "bundle",
+    images = {
+        "ghcr.io/<OWNER>/image1:tag": ":app1",
+        "ghcr.io/<OWNER>/image2:tag": ":app2",
+    },
+)
+```
+"""
+
+_attrs = {
+    "image_refs": attr.string_list(mandatory = True, doc = "List of references."),
+    "image_targets": attr.label_list(mandatory = True, doc = "List of labels to oci_image/oci_image_index/oci_bundle targets."),
+    "_bundle_sh_tpl": attr.label(default = "bundle.sh.tpl", allow_single_file = True),
+}
+
+def _expand_image_to_args(image, expander):
+    args = [
+        "--image={}".format(image.path),
+    ]
+    for file in expander.expand(image):
+        if file.path.find("blobs") != -1:
+            args.append("--blob={}".format(file.tree_relative_path))
+    return args
+
+def _oci_bundle_impl(ctx):
+    yq = ctx.toolchains["@aspect_bazel_lib//lib:yq_toolchain_type"]
+    coreutils = ctx.toolchains["@aspect_bazel_lib//lib:coreutils_toolchain_type"]
+
+    launcher = ctx.actions.declare_file("bundle_{}.sh".format(ctx.label.name))
+    ctx.actions.expand_template(
+        template = ctx.file._bundle_sh_tpl,
+        output = launcher,
+        is_executable = True,
+        substitutions = {
+            "{{yq_path}}": yq.yqinfo.bin.path,
+            "{{coreutils_path}}": coreutils.coreutils_info.bin.path,
+        },
+    )
+
+    output = ctx.actions.declare_directory(ctx.label.name)
+
+    args = ctx.actions.args()
+    args.add(output.path, format = "--output=%s")
+    for i in range(len(ctx.files.image_targets)):
+        ref = ctx.attr.image_refs[i]
+        args.add_all([ctx.files.image_targets[i]], map_each = _expand_image_to_args, expand_directories = False)
+        args.add(ref, format = "--ref=%s")
+
+    ctx.actions.run(
+        inputs = ctx.files.image_targets,
+        arguments = [args],
+        outputs = [output],
+        executable = launcher,
+        tools = [yq.yqinfo.bin, coreutils.coreutils_info.bin],
+        mnemonic = "OCIBundle",
+        progress_message = "OCI Bundle %{label}",
+    )
+
+    return DefaultInfo(files = depset([output]))
+
+oci_bundle = rule(
+    implementation = _oci_bundle_impl,
+    attrs = _attrs,
+    doc = _DOC,
+    toolchains = [
+        "@aspect_bazel_lib//lib:yq_toolchain_type",
+        "@aspect_bazel_lib//lib:coreutils_toolchain_type",
+    ],
+)

--- a/oci/private/bundle.sh.tpl
+++ b/oci/private/bundle.sh.tpl
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -o pipefail -o errexit -o nounset
+
+readonly YQ="{{yq_path}}"
+readonly COREUTILS="{{coreutils_path}}"
+
+# Only crete the directory if it doesn't already exist.
+# Otherwise we may attempt to modify permissions of an existing directory.
+# See https://github.com/bazel-contrib/rules_oci/pull/271
+function mkdirp() {
+    test -d "$1" || "${COREUTILS}" mkdir -p "$1"
+}
+
+function copy_blob() {
+    local image_path="$1"
+    local output_path="$2"
+    local blob_image_relative_path="$3"
+    local dest_path="${output_path}/${blob_image_relative_path}"
+    mkdirp "$(dirname "${dest_path}")"
+    "${COREUTILS}" ln -f "${image_path}/${blob_image_relative_path}" "${dest_path}"
+}
+
+function create_oci_layout() {
+    local path="$1"
+    mkdirp "${path}"
+
+    echo '{"imageLayoutVersion": "1.0.0"}' > "${path}/oci-layout" 
+    echo '{"schemaVersion": 2, "manifests": []}' > "${path}/index.json"
+}
+
+function append_manifest() {
+    local image_path="$1"
+    local output_path="$2"
+    local ref="$3"
+
+    "${YQ}" --inplace --output-format=json ".manifests += $(${YQ} '.manifests' ${image_path}/index.json | ${YQ} eval "(.[].annotations[\"org.opencontainers.image.ref.name\"] | select(. == null)) |= \"${ref}\"" -M -o json -I 0)" "${output_path}/index.json"
+}
+
+CURRENT_IMAGE=""
+OUTPUT=""
+
+for ARG in "$@"; do
+    case "$ARG" in
+        (--output=*) OUTPUT="${ARG#--output=}"; create_oci_layout "$OUTPUT" ;;
+        (--image=*) CURRENT_IMAGE="${ARG#--image=}";;
+        (--blob=*) copy_blob "${CURRENT_IMAGE}" "$OUTPUT" "${ARG#--blob=}" ;;
+        (--ref=*) append_manifest "${CURRENT_IMAGE}" "$OUTPUT" "${ARG#--ref=}";;
+        (*) echo "Unknown argument ${ARG}"; exit 1;;
+    esac
+done


### PR DESCRIPTION
similar to crane pull --format=oci image1 image2 output-dir, but locally

Preparation of https://github.com/bazel-contrib/rules_oci/issues/248

( I create https://github.com/google/go-containerregistry/pull/1787 to support push bundle. )

but we should support bundle first.