### PR TITLE
fix: Propagate all tags, not just well known ones

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -118,7 +118,7 @@ This is similar to the same-named target created by rules_docker's `container_im
 | <a id="oci_image-env"></a>env |  Environment variables provisioned by default to the running container. See documentation above.   |  <code>None</code> |
 | <a id="oci_image-cmd"></a>cmd |  Command & argument configured by default in the running container. See documentation above.   |  <code>None</code> |
 | <a id="oci_image-entrypoint"></a>entrypoint |  Entrypoint configured by default in the running container. See documentation above.   |  <code>None</code> |
-| <a id="oci_image-tags"></a>tags |  Tags to propagate to targets declared by this macro. Input will be filtered to well known tags only. See [propagate_well_known_tags] (https://github.com/aspect-build/bazel-lib/blob/main/docs/utils.md#propagate_well_known_tags) for details.   |  <code>[]</code> |
+| <a id="oci_image-tags"></a>tags |  Tags to propagate to targets declared by this macro.   |  <code>[]</code> |
 | <a id="oci_image-kwargs"></a>kwargs |  other named arguments to [oci_image_rule](#oci_image_rule)   |  none |
 
 

--- a/docs/push.md
+++ b/docs/push.md
@@ -137,7 +137,7 @@ Allows the remote_tags attribute to be a list of strings in addition to a text f
 | :------------- | :------------- | :------------- |
 | <a id="oci_push-name"></a>name |  name of resulting oci_push_rule   |  none |
 | <a id="oci_push-remote_tags"></a>remote_tags |  a list of tags to apply to the image after pushing, or a label of a file containing tags one-per-line. See [stamped_tags](https://github.com/bazel-contrib/rules_oci/blob/main/examples/push/stamp_tags.bzl) as one example of a way to produce such a file.   |  <code>None</code> |
-| <a id="oci_push-tags"></a>tags |  Tags to propagate to targets declared by this macro. Input will be filtered to well known tags only. See [propagate_well_known_tags] (https://github.com/aspect-build/bazel-lib/blob/main/docs/utils.md#propagate_well_known_tags) for details.   |  <code>[]</code> |
+| <a id="oci_push-tags"></a>tags |  Tags to propagate to targets declared by this macro.   |  <code>[]</code> |
 | <a id="oci_push-kwargs"></a>kwargs |  other named arguments to [oci_push_rule](#oci_push_rule).   |  none |
 
 


### PR DESCRIPTION
In trying to fix tag propagation, #350 broke tag propagation behavior for some targets which did have tags forwarded properly. The reason the behavior changed is because while we are still propagating tags in #350, we started passing them through [propagate_well_known_tags](https://github.com/aspect-build/bazel-lib/blob/main/docs/utils.md#propagate_well_known_tags) which caused some issues, e.g. https://github.com/bazel-contrib/rules_oci/pull/350#issuecomment-1724530364.

This restores the old behavior for the targets which did have tags propagated, while also propagating all tags for the new targets.