### PR TITLE
fix: forward well known attributes to macro expanded targets

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,7 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "aspect_bazel_lib", version = "1.32.0")
+bazel_dep(name = "aspect_bazel_lib", version = "1.35.0")
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "platforms", version = "0.0.5")
 

--- a/docs/image.md
+++ b/docs/image.md
@@ -118,6 +118,6 @@ This is similar to the same-named target created by rules_docker's `container_im
 | <a id="oci_image-env"></a>env |  Environment variables provisioned by default to the running container. See documentation above.   |  <code>None</code> |
 | <a id="oci_image-cmd"></a>cmd |  Command & argument configured by default in the running container. See documentation above.   |  <code>None</code> |
 | <a id="oci_image-entrypoint"></a>entrypoint |  Entrypoint configured by default in the running container. See documentation above.   |  <code>None</code> |
-| <a id="oci_image-kwargs"></a>kwargs |  other named arguments to [oci_image_rule](#oci_image_rule) and [common rule attribtes](https://bazel.build/reference/be/common-definitions#common-attributes).   |  none |
+| <a id="oci_image-kwargs"></a>kwargs |  other named arguments to [oci_image_rule](#oci_image_rule) and [common rule attributes](https://bazel.build/reference/be/common-definitions#common-attributes).   |  none |
 
 

--- a/docs/image.md
+++ b/docs/image.md
@@ -90,7 +90,7 @@ oci_image(
 ## oci_image
 
 <pre>
-oci_image(<a href="#oci_image-name">name</a>, <a href="#oci_image-labels">labels</a>, <a href="#oci_image-annotations">annotations</a>, <a href="#oci_image-env">env</a>, <a href="#oci_image-cmd">cmd</a>, <a href="#oci_image-entrypoint">entrypoint</a>, <a href="#oci_image-tags">tags</a>, <a href="#oci_image-kwargs">kwargs</a>)
+oci_image(<a href="#oci_image-name">name</a>, <a href="#oci_image-labels">labels</a>, <a href="#oci_image-annotations">annotations</a>, <a href="#oci_image-env">env</a>, <a href="#oci_image-cmd">cmd</a>, <a href="#oci_image-entrypoint">entrypoint</a>, <a href="#oci_image-kwargs">kwargs</a>)
 </pre>
 
 Macro wrapper around [oci_image_rule](#oci_image_rule).
@@ -118,7 +118,6 @@ This is similar to the same-named target created by rules_docker's `container_im
 | <a id="oci_image-env"></a>env |  Environment variables provisioned by default to the running container. See documentation above.   |  <code>None</code> |
 | <a id="oci_image-cmd"></a>cmd |  Command & argument configured by default in the running container. See documentation above.   |  <code>None</code> |
 | <a id="oci_image-entrypoint"></a>entrypoint |  Entrypoint configured by default in the running container. See documentation above.   |  <code>None</code> |
-| <a id="oci_image-tags"></a>tags |  Tags to propagate to targets declared by this macro.   |  <code>[]</code> |
-| <a id="oci_image-kwargs"></a>kwargs |  other named arguments to [oci_image_rule](#oci_image_rule)   |  none |
+| <a id="oci_image-kwargs"></a>kwargs |  other named arguments to [oci_image_rule](#oci_image_rule) and [common rule attribtes](https://bazel.build/reference/be/common-definitions#common-attributes).   |  none |
 
 

--- a/docs/push.md
+++ b/docs/push.md
@@ -149,6 +149,6 @@ Allows the remote_tags attribute to be a list of strings in addition to a text f
 | :------------- | :------------- | :------------- |
 | <a id="oci_push-name"></a>name |  name of resulting oci_push_rule   |  none |
 | <a id="oci_push-remote_tags"></a>remote_tags |  a list of tags to apply to the image after pushing, or a label of a file containing tags one-per-line. See [stamped_tags](https://github.com/bazel-contrib/rules_oci/blob/main/examples/push/stamp_tags.bzl) as one example of a way to produce such a file.   |  <code>None</code> |
-| <a id="oci_push-kwargs"></a>kwargs |  other named arguments to [oci_push_rule](#oci_push_rule) and [common rule attribtes](https://bazel.build/reference/be/common-definitions#common-attributes).   |  none |
+| <a id="oci_push-kwargs"></a>kwargs |  other named arguments to [oci_push_rule](#oci_push_rule) and [common rule attributes](https://bazel.build/reference/be/common-definitions#common-attributes).   |  none |
 
 

--- a/docs/push.md
+++ b/docs/push.md
@@ -134,7 +134,7 @@ oci_push(
 ## oci_push
 
 <pre>
-oci_push(<a href="#oci_push-name">name</a>, <a href="#oci_push-remote_tags">remote_tags</a>, <a href="#oci_push-tags">tags</a>, <a href="#oci_push-kwargs">kwargs</a>)
+oci_push(<a href="#oci_push-name">name</a>, <a href="#oci_push-remote_tags">remote_tags</a>, <a href="#oci_push-kwargs">kwargs</a>)
 </pre>
 
 Macro wrapper around [oci_push_rule](#oci_push_rule).
@@ -149,7 +149,6 @@ Allows the remote_tags attribute to be a list of strings in addition to a text f
 | :------------- | :------------- | :------------- |
 | <a id="oci_push-name"></a>name |  name of resulting oci_push_rule   |  none |
 | <a id="oci_push-remote_tags"></a>remote_tags |  a list of tags to apply to the image after pushing, or a label of a file containing tags one-per-line. See [stamped_tags](https://github.com/bazel-contrib/rules_oci/blob/main/examples/push/stamp_tags.bzl) as one example of a way to produce such a file.   |  <code>None</code> |
-| <a id="oci_push-tags"></a>tags |  Tags to propagate to targets declared by this macro.   |  <code>[]</code> |
-| <a id="oci_push-kwargs"></a>kwargs |  other named arguments to [oci_push_rule](#oci_push_rule).   |  none |
+| <a id="oci_push-kwargs"></a>kwargs |  other named arguments to [oci_push_rule](#oci_push_rule) and [common rule attribtes](https://bazel.build/reference/be/common-definitions#common-attributes).   |  none |
 
 

--- a/oci/defs.bzl
+++ b/oci/defs.bzl
@@ -22,7 +22,7 @@ oci_image_rule = _oci_image
 oci_image_index = _oci_image_index
 oci_push_rule = _oci_push
 
-def oci_image(name, labels = None, annotations = None, env = None, cmd = None, entrypoint = None, tags = [], **kwargs):
+def oci_image(name, labels = None, annotations = None, env = None, cmd = None, entrypoint = None, **kwargs):
     """Macro wrapper around [oci_image_rule](#oci_image_rule).
 
     Allows labels and annotations to be provided as a dictionary, in addition to a text file.
@@ -43,8 +43,8 @@ def oci_image(name, labels = None, annotations = None, env = None, cmd = None, e
         env: Environment variables provisioned by default to the running container. See documentation above.
         cmd: Command & argument configured by default in the running container. See documentation above.
         entrypoint: Entrypoint configured by default in the running container. See documentation above.
-        tags: Tags to propagate to targets declared by this macro.
-        **kwargs: other named arguments to [oci_image_rule](#oci_image_rule)
+        **kwargs: other named arguments to [oci_image_rule](#oci_image_rule) and
+            [common rule attribtes](https://bazel.build/reference/be/common-definitions#common-attributes).
     """
     forwarded_kwargs = propagate_common_rule_attributes(kwargs)
 
@@ -54,7 +54,6 @@ def oci_image(name, labels = None, annotations = None, env = None, cmd = None, e
             name = annotations_label,
             out = "_{}.annotations.txt".format(name),
             content = ["{}={}".format(key, value) for (key, value) in annotations.items()],
-            tags = tags,
             **forwarded_kwargs,
         )
         annotations = annotations_label
@@ -65,7 +64,6 @@ def oci_image(name, labels = None, annotations = None, env = None, cmd = None, e
             name = labels_label,
             out = "_{}.labels.txt".format(name),
             content = ["{}={}".format(key, value) for (key, value) in labels.items()],
-            tags = tags,
             **forwarded_kwargs,
         )
         labels = labels_label
@@ -76,7 +74,6 @@ def oci_image(name, labels = None, annotations = None, env = None, cmd = None, e
             name = env_label,
             out = "_{}.env.txt".format(name),
             content = ["{}={}".format(key, value) for (key, value) in env.items()],
-            tags = tags,
             **forwarded_kwargs,
         )
         env = env_label
@@ -87,7 +84,6 @@ def oci_image(name, labels = None, annotations = None, env = None, cmd = None, e
             name = env_label,
             out = "_{}.env.txt".format(name),
             content = ["{}={}".format(key, value) for (key, value) in env.items()],
-            tags = tags,
             **forwarded_kwargs,
         )
         env = env_label
@@ -98,7 +94,6 @@ def oci_image(name, labels = None, annotations = None, env = None, cmd = None, e
             name = cmd_label,
             out = "_{}.cmd.txt".format(name),
             content = [",".join(cmd)],
-            tags = tags,
             **forwarded_kwargs,
         )
         cmd = cmd_label
@@ -109,7 +104,6 @@ def oci_image(name, labels = None, annotations = None, env = None, cmd = None, e
             name = entrypoint_label,
             out = "_{}.entrypoint.txt".format(name),
             content = [",".join(entrypoint)],
-            tags = tags,
             **forwarded_kwargs,
         )
         entrypoint = entrypoint_label
@@ -121,7 +115,6 @@ def oci_image(name, labels = None, annotations = None, env = None, cmd = None, e
         env = env,
         cmd = cmd,
         entrypoint = entrypoint,
-        tags = tags,
         **kwargs
     )
 
@@ -131,7 +124,6 @@ def oci_image(name, labels = None, annotations = None, env = None, cmd = None, e
         name = "_{}_index_json".format(name),
         directory = name,
         path = "index.json",
-        tags = tags,
         **forwarded_kwargs,
     )
 
@@ -139,7 +131,6 @@ def oci_image(name, labels = None, annotations = None, env = None, cmd = None, e
         name = "_{}_index_json_cp".format(name),
         src = "_{}_index_json".format(name),
         out = "_{}_index.json".format(name),
-        tags = tags,
         **forwarded_kwargs,
     )
 
@@ -150,11 +141,10 @@ def oci_image(name, labels = None, annotations = None, env = None, cmd = None, e
         srcs = ["_{}_index.json".format(name)],
         filter = """.manifests[0].digest""",
         out = name + ".json.sha256",  # path chosen to match rules_docker for easy migration
-        tags = tags,
         **forwarded_kwargs,
     )
 
-def oci_push(name, remote_tags = None, tags = [], **kwargs):
+def oci_push(name, remote_tags = None, **kwargs):
     """Macro wrapper around [oci_push_rule](#oci_push_rule).
 
     Allows the remote_tags attribute to be a list of strings in addition to a text file.
@@ -165,27 +155,28 @@ def oci_push(name, remote_tags = None, tags = [], **kwargs):
             or a label of a file containing tags one-per-line.
             See [stamped_tags](https://github.com/bazel-contrib/rules_oci/blob/main/examples/push/stamp_tags.bzl)
             as one example of a way to produce such a file.
-        tags: Tags to propagate to targets declared by this macro.
-        **kwargs: other named arguments to [oci_push_rule](#oci_push_rule).
+        **kwargs: other named arguments to [oci_push_rule](#oci_push_rule) and
+            [common rule attribtes](https://bazel.build/reference/be/common-definitions#common-attributes).
     """
+    forwarded_kwargs = propagate_common_rule_attributes(kwargs)
+
     if types.is_list(remote_tags):
         tags_label = "_{}_write_tags".format(name)
         write_file(
             name = tags_label,
             out = "_{}.tags.txt".format(name),
             content = remote_tags,
-            tags = tags,
+            **forwarded_kwargs,
         )
         remote_tags = tags_label
 
     oci_push_rule(
         name = name,
         remote_tags = remote_tags,
-        tags = tags,
         **kwargs
     )
 
-def oci_tarball(name, repo_tags = None, tags = [], **kwargs):
+def oci_tarball(name, repo_tags = None, **kwargs):
     """Macro wrapper around [oci_tarball_rule](#oci_tarball_rule).
 
     Allows the repo_tags attribute to be a list of strings in addition to a text file.
@@ -196,8 +187,8 @@ def oci_tarball(name, repo_tags = None, tags = [], **kwargs):
             or a label of a file containing tags one-per-line.
             See [stamped_tags](https://github.com/bazel-contrib/rules_oci/blob/main/examples/push/stamp_tags.bzl)
             as one example of a way to produce such a file.
-        tags: Tags to propagate to targets declared by this macro.
-        **kwargs: other named arguments to [oci_tarball_rule](#oci_tarball_rule).
+        **kwargs: other named arguments to [oci_tarball_rule](#oci_tarball_rule) and
+            [common rule attribtes](https://bazel.build/reference/be/common-definitions#common-attributes).
     """
     forwarded_kwargs = propagate_common_rule_attributes(kwargs)
 
@@ -207,7 +198,6 @@ def oci_tarball(name, repo_tags = None, tags = [], **kwargs):
             name = tags_label,
             out = "_{}.tags.txt".format(name),
             content = repo_tags,
-            tags = tags,
             **forwarded_kwargs,
         )
         repo_tags = tags_label
@@ -215,6 +205,5 @@ def oci_tarball(name, repo_tags = None, tags = [], **kwargs):
     oci_tarball_rule(
         name = name,
         repo_tags = repo_tags,
-        tags = tags,
         **kwargs
     )

--- a/oci/defs.bzl
+++ b/oci/defs.bzl
@@ -44,7 +44,7 @@ def oci_image(name, labels = None, annotations = None, env = None, cmd = None, e
         cmd: Command & argument configured by default in the running container. See documentation above.
         entrypoint: Entrypoint configured by default in the running container. See documentation above.
         **kwargs: other named arguments to [oci_image_rule](#oci_image_rule) and
-            [common rule attribtes](https://bazel.build/reference/be/common-definitions#common-attributes).
+            [common rule attributes](https://bazel.build/reference/be/common-definitions#common-attributes).
     """
     forwarded_kwargs = propagate_common_rule_attributes(kwargs)
 
@@ -156,7 +156,7 @@ def oci_push(name, remote_tags = None, **kwargs):
             See [stamped_tags](https://github.com/bazel-contrib/rules_oci/blob/main/examples/push/stamp_tags.bzl)
             as one example of a way to produce such a file.
         **kwargs: other named arguments to [oci_push_rule](#oci_push_rule) and
-            [common rule attribtes](https://bazel.build/reference/be/common-definitions#common-attributes).
+            [common rule attributes](https://bazel.build/reference/be/common-definitions#common-attributes).
     """
     forwarded_kwargs = propagate_common_rule_attributes(kwargs)
 
@@ -188,7 +188,7 @@ def oci_tarball(name, repo_tags = None, **kwargs):
             See [stamped_tags](https://github.com/bazel-contrib/rules_oci/blob/main/examples/push/stamp_tags.bzl)
             as one example of a way to produce such a file.
         **kwargs: other named arguments to [oci_tarball_rule](#oci_tarball_rule) and
-            [common rule attribtes](https://bazel.build/reference/be/common-definitions#common-attributes).
+            [common rule attributes](https://bazel.build/reference/be/common-definitions#common-attributes).
     """
     forwarded_kwargs = propagate_common_rule_attributes(kwargs)
 

--- a/oci/defs.bzl
+++ b/oci/defs.bzl
@@ -9,6 +9,7 @@ load("@rules_oci//oci:defs.bzl", ...)
 load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@aspect_bazel_lib//lib:directory_path.bzl", "directory_path")
 load("@aspect_bazel_lib//lib:jq.bzl", "jq")
+load("@aspect_bazel_lib//lib:utils.bzl", "propagate_common_rule_attributes")
 load("@bazel_skylib//lib:types.bzl", "types")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("//oci/private:image.bzl", _oci_image = "oci_image")
@@ -45,6 +46,8 @@ def oci_image(name, labels = None, annotations = None, env = None, cmd = None, e
         tags: Tags to propagate to targets declared by this macro.
         **kwargs: other named arguments to [oci_image_rule](#oci_image_rule)
     """
+    forwarded_kwargs = propagate_common_rule_attributes(kwargs)
+
     if types.is_dict(annotations):
         annotations_label = "_{}_write_annotations".format(name)
         write_file(
@@ -52,6 +55,7 @@ def oci_image(name, labels = None, annotations = None, env = None, cmd = None, e
             out = "_{}.annotations.txt".format(name),
             content = ["{}={}".format(key, value) for (key, value) in annotations.items()],
             tags = tags,
+            **forwarded_kwargs,
         )
         annotations = annotations_label
 
@@ -62,6 +66,7 @@ def oci_image(name, labels = None, annotations = None, env = None, cmd = None, e
             out = "_{}.labels.txt".format(name),
             content = ["{}={}".format(key, value) for (key, value) in labels.items()],
             tags = tags,
+            **forwarded_kwargs,
         )
         labels = labels_label
 
@@ -72,6 +77,7 @@ def oci_image(name, labels = None, annotations = None, env = None, cmd = None, e
             out = "_{}.env.txt".format(name),
             content = ["{}={}".format(key, value) for (key, value) in env.items()],
             tags = tags,
+            **forwarded_kwargs,
         )
         env = env_label
 
@@ -82,6 +88,7 @@ def oci_image(name, labels = None, annotations = None, env = None, cmd = None, e
             out = "_{}.env.txt".format(name),
             content = ["{}={}".format(key, value) for (key, value) in env.items()],
             tags = tags,
+            **forwarded_kwargs,
         )
         env = env_label
 
@@ -92,6 +99,7 @@ def oci_image(name, labels = None, annotations = None, env = None, cmd = None, e
             out = "_{}.cmd.txt".format(name),
             content = [",".join(cmd)],
             tags = tags,
+            **forwarded_kwargs,
         )
         cmd = cmd_label
 
@@ -102,6 +110,7 @@ def oci_image(name, labels = None, annotations = None, env = None, cmd = None, e
             out = "_{}.entrypoint.txt".format(name),
             content = [",".join(entrypoint)],
             tags = tags,
+            **forwarded_kwargs,
         )
         entrypoint = entrypoint_label
 
@@ -123,6 +132,7 @@ def oci_image(name, labels = None, annotations = None, env = None, cmd = None, e
         directory = name,
         path = "index.json",
         tags = tags,
+        **forwarded_kwargs,
     )
 
     copy_file(
@@ -130,6 +140,7 @@ def oci_image(name, labels = None, annotations = None, env = None, cmd = None, e
         src = "_{}_index_json".format(name),
         out = "_{}_index.json".format(name),
         tags = tags,
+        **forwarded_kwargs,
     )
 
     # Matches the [name].digest target produced by rules_docker container_image
@@ -140,6 +151,7 @@ def oci_image(name, labels = None, annotations = None, env = None, cmd = None, e
         filter = """.manifests[0].digest""",
         out = name + ".json.sha256",  # path chosen to match rules_docker for easy migration
         tags = tags,
+        **forwarded_kwargs,
     )
 
 def oci_push(name, remote_tags = None, tags = [], **kwargs):
@@ -187,6 +199,8 @@ def oci_tarball(name, repo_tags = None, tags = [], **kwargs):
         tags: Tags to propagate to targets declared by this macro.
         **kwargs: other named arguments to [oci_tarball_rule](#oci_tarball_rule).
     """
+    forwarded_kwargs = propagate_common_rule_attributes(kwargs)
+
     if types.is_list(repo_tags):
         tags_label = "_{}_write_tags".format(name)
         write_file(
@@ -194,6 +208,7 @@ def oci_tarball(name, repo_tags = None, tags = [], **kwargs):
             out = "_{}.tags.txt".format(name),
             content = repo_tags,
             tags = tags,
+            **forwarded_kwargs,
         )
         repo_tags = tags_label
 

--- a/oci/dependencies.bzl
+++ b/oci/dependencies.bzl
@@ -29,7 +29,7 @@ def rules_oci_dependencies():
 
     http_archive(
         name = "aspect_bazel_lib",
-        sha256 = "f1c181b910f821072f38ee45bb87db6b56275458c7f832c54c54ba6334119eca",
-        strip_prefix = "bazel-lib-1.32.0",
-        url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.32.0/bazel-lib-v1.32.0.tar.gz",
+        sha256 = "e9505bd956da64b576c433e4e41da76540fd8b889bbd17617fe480a646b1bfb9",
+        strip_prefix = "bazel-lib-1.35.0",
+        url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.35.0/bazel-lib-v1.35.0.tar.gz",
     )


### PR DESCRIPTION
As per #369, trying to put a test in an `oci_image` target by making it `testonly = True` is currently broken.

This PR just adds the common rule attribute`testonly` to the `oci_image` and `oci_tarball` macros and forwards its value along to all the rules they instantiate.