### PR TITLE
oci_tarball: fix file time to 2000-01-01 for files inside the tar

### DIFF
--- a/oci/private/tarball.sh.tpl
+++ b/oci/private/tarball.sh.tpl
@@ -35,4 +35,4 @@ layers="${LAYERS}" \
         --output-format json > "${STAGING_DIR}/manifest.json"
 
 # TODO: https://github.com/bazel-contrib/rules_oci/issues/217
-tar -C "${STAGING_DIR}" -cf "${TARBALL_PATH}" manifest.json blobs
+tar -C "${STAGING_DIR}" -cf "${TARBALL_PATH}" --mtime='2000-01-01' manifest.json blobs


### PR DESCRIPTION
This way we can generate reproducible tars and avoid sha256sums changing for the tar output of the oci_tarball rule.