### PR TITLE
oci_tarball: set time, user and group to reproducible values for Linux

### DIFF
--- a/oci/private/tarball.sh.tpl
+++ b/oci/private/tarball.sh.tpl
@@ -34,5 +34,15 @@ layers="${LAYERS}" \
         --null-input '.[0] = {"Config": env(config), "RepoTags": "${repo_tags}" | envsubst | split("%") | map(select(. != "")) , "Layers": env(layers) | map( "blobs/" + . + ".tar.gz") }' \
         --output-format json > "${STAGING_DIR}/manifest.json"
 
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  reproducible_flags="--mtime=2000-01-01 --owner=0 --group=0 --numeric-owner"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  # FIXME: add necessary attributes or wait for tar toolchain.
+  reproducible_flags=""
+else
+  # FIXME: add necessary attributes or wait for tar toolchain.
+  reproducible_flags=""
+fi
+
 # TODO: https://github.com/bazel-contrib/rules_oci/issues/217
-tar -C "${STAGING_DIR}" -cf "${TARBALL_PATH}" manifest.json blobs
+tar -C "${STAGING_DIR}" -cf "${TARBALL_PATH}" $reproducible_flags manifest.json blobs


### PR DESCRIPTION
Applied suggestion for Linux from:

http://h2.jaguarpaw.co.uk/posts/reproducible-tar/

Left out MacOS and other systems for now (waiting for tar toolchain).
MacOS does not have the same options for tar, for now fixing this only
for Linux.