### PR TITLE
Revert "oci_tarball: set mtime to 2000-01-01"

### DIFF
--- a/oci/private/tarball.sh.tpl
+++ b/oci/private/tarball.sh.tpl
@@ -35,4 +35,4 @@ layers="${LAYERS}" \
         --output-format json > "${STAGING_DIR}/manifest.json"
 
 # TODO: https://github.com/bazel-contrib/rules_oci/issues/217
-tar -C "${STAGING_DIR}" -cf "${TARBALL_PATH}" --mtime='2000-01-01' manifest.json blobs
+tar -C "${STAGING_DIR}" -cf "${TARBALL_PATH}" manifest.json blobs


### PR DESCRIPTION
Reverts bazel-contrib/rules_oci#380

It broke MacOS CI (only on main build sadly)