### PR TITLE
chore: enable some CI on macos again

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,8 +39,7 @@ jobs:
         run: echo "os=ubuntu-latest" >> $GITHUB_OUTPUT
       - id: rbe
         run: echo "os=macos-latest" >> $GITHUB_OUTPUT
-        # Don't run MocOS if there is no TestContainers API token which is the case on forks
-        # We expect to use it at some point for tests that need a docker daemon.
+        # Don't run MacOS if there is no TestContainers API token which is the case on forks. We need it for container tests.
         if: ${{ env.TC_CLOUD_TOKEN != '' }}
     outputs:
       # Will look like ["ubuntu-latest", "macos-latest"]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - id: linux
         run: echo "os=ubuntu-latest" >> $GITHUB_OUTPUT
-      - id: rbe
+      - id: macos
         run: echo "os=macos-latest" >> $GITHUB_OUTPUT
         # Don't run MacOS if there is no TestContainers API token which is the case on forks. We need it for container tests.
         if: ${{ env.TC_CLOUD_TOKEN != '' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,6 +67,13 @@ jobs:
 
         bzlmodEnabled: [true, false]
         exclude:
+          # macos is expensive so don't test these
+          - os: macos-latest 
+            folder: e2e/custom_registry
+          - os: macos-latest 
+            folder: e2e/wasm
+          - os: macos-latest 
+            folder: e2e/crane_as_registry
           # Don't test bzlmod with Bazel 5 (not supported)
           - bazelversion: 5.3.2
             bzlmodEnabled: true
@@ -103,12 +110,24 @@ jobs:
         working-directory: ${{ matrix.folder }}
         run: echo "${{ matrix.bazelversion }}" > .bazelversion
 
+      - name: Configure TestContainers cloud
+        if: ${{ matrix.os == 'macos-latest' }}
+        uses: atomicjar/testcontainers-cloud-setup-action@main
+        with:
+            wait: true
+            token: ${{ secrets.TC_CLOUD_TOKEN }}
+      
+      - name: Setup Remote Docker
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: echo "DOCKER_HOST=$(cat ~/.testcontainers.properties | grep 'docker.host' | cut -d '=' -f2 | xargs)" >> $GITHUB_ENV
+
       - name: bazel test //...
         working-directory: ${{ matrix.folder }}
         env:
           # Bazelisk will download bazel to here, ensure it is cached between runs.
           XDG_CACHE_HOME: ~/.cache/bazel-repo
         run: bazel --bazelrc=$GITHUB_WORKSPACE/.github/workflows/ci.bazelrc --bazelrc=.bazelrc test ${{ steps.set_bzlmod_flag.outputs.bzlmod_flag }} //...
+  
   test-auth:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,16 +29,34 @@ jobs:
       # Will look like ["<version from .bazelversion>", "5.3.2"]
       bazelversions: ${{ toJSON(steps.*.outputs.bazelversion) }}
 
+  matrix-prep-os:
+    # Prepares the 'os' axis of the test matrix
+    runs-on: ubuntu-latest
+    env:
+      TC_CLOUD_TOKEN: ${{ secrets.TC_CLOUD_TOKEN }}
+    steps:
+      - id: linux
+        run: echo "os=ubuntu-latest" >> $GITHUB_OUTPUT
+      - id: rbe
+        run: echo "os=macos-latest" >> $GITHUB_OUTPUT
+        # Don't run MocOS if there is no TestContainers API token which is the case on forks
+        # We expect to use it at some point for tests that need a docker daemon.
+        if: ${{ env.TC_CLOUD_TOKEN != '' }}
+    outputs:
+      # Will look like ["ubuntu-latest", "macos-latest"]
+      os: ${{ toJSON(steps.*.outputs.os) }}
+
   test:
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
     needs:
       - matrix-prep-bazelversion
+      - matrix-prep-os
 
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: ${{ fromJSON(needs.matrix-prep-os.outputs.os) }}
         bazelversion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions) }}
         folder:
           - .


### PR DESCRIPTION
We need at least some coverage, even if we don't have a container runtime there