### PR TITLE
fix: forward well known attributes to macro expanded targets (#370)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,7 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "aspect_bazel_lib", version = "1.32.0")
+bazel_dep(name = "aspect_bazel_lib", version = "1.35.0")
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "platforms", version = "0.0.5")
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,14 +2,15 @@
 # This is *not* included in the published distribution.
 workspace(name = "rules_oci")
 
-load(":internal_deps.bzl", "rules_oci_internal_deps")
-
 # Fetch deps needed only locally for development
+load(":internal_deps.bzl", "rules_oci_internal_deps")
 rules_oci_internal_deps()
 
-load("//oci:dependencies.bzl", "rules_oci_dependencies")
+load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
+stardoc_repositories()
 
 # Fetch our "runtime" dependencies which users need as well
+load("//oci:dependencies.bzl", "rules_oci_dependencies")
 rules_oci_dependencies()
 
 load("//oci:repositories.bzl", "LATEST_CRANE_VERSION", "LATEST_ZOT_VERSION", "oci_register_toolchains")

--- a/docs/image.md
+++ b/docs/image.md
@@ -8,7 +8,7 @@ load("@rules_oci//oci:defs.bzl", ...)
 ```
 
 
-<a id="#oci_image_rule"></a>
+<a id="oci_image_rule"></a>
 
 ## oci_image_rule
 
@@ -70,22 +70,22 @@ oci_image(
 
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="oci_image_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
-| <a id="oci_image_rule-annotations"></a>annotations |  A file containing a dictionary of annotations. Each line should be in the form <code>name=value</code>.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
-| <a id="oci_image_rule-architecture"></a>architecture |  The CPU architecture which the binaries in this image are built to run on. eg: <code>arm64</code>, <code>arm</code>, <code>amd64</code>, <code>s390x</code>. See $GOARCH documentation for possible values: https://go.dev/doc/install/source#environment   | String | optional | "" |
-| <a id="oci_image_rule-base"></a>base |  Label to an oci_image target to use as the base.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
-| <a id="oci_image_rule-cmd"></a>cmd |  A file containing a comma separated list to be used as the <code>command & args</code> of the container. These values act as defaults and may be replaced by any specified when creating a container.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
-| <a id="oci_image_rule-entrypoint"></a>entrypoint |  A file containing a comma separated list to be used as the <code>entrypoint</code> to execute when the container starts. These values act as defaults and may be replaced by an entrypoint specified when creating a container.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
-| <a id="oci_image_rule-env"></a>env |  A file containing the default values for the environment variables of the container. These values act as defaults and are merged with any specified when creating a container. Entries replace the base environment variables if any of the entries has conflicting keys. To merge entries with keys specified in the base, <code>${KEY}</code> or <code>$KEY</code> syntax may be used.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
-| <a id="oci_image_rule-labels"></a>labels |  A file containing a dictionary of labels. Each line should be in the form <code>name=value</code>.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
-| <a id="oci_image_rule-os"></a>os |  The name of the operating system which the image is built to run on. eg: <code>linux</code>, <code>windows</code>. See $GOOS documentation for possible values: https://go.dev/doc/install/source#environment   | String | optional | "" |
-| <a id="oci_image_rule-tars"></a>tars |  List of tar files to add to the image as layers.         Do not sort this list; the order is preserved in the resulting image.         Less-frequently changed files belong in lower layers to reduce the network bandwidth required to pull and push.<br><br>        The authors recommend [dive](https://github.com/wagoodman/dive) to explore the layering of the resulting image.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
-| <a id="oci_image_rule-user"></a>user |  The <code>username</code> or <code>UID</code> which is a platform-specific structure that allows specific control over which user the process run as. This acts as a default value to use when the value is not specified when creating a container. For Linux based systems, all of the following are valid: <code>user</code>, <code>uid</code>, <code>user:group</code>, <code>uid:gid</code>, <code>uid:group</code>, <code>user:gid</code>. If <code>group/gid</code> is not specified, the default group and supplementary groups of the given <code>user/uid</code> in <code>/etc/passwd</code> from the container are applied.   | String | optional | "" |
-| <a id="oci_image_rule-variant"></a>variant |  The variant of the specified CPU architecture. eg: <code>v6</code>, <code>v7</code>, <code>v8</code>. See: https://github.com/opencontainers/image-spec/blob/main/image-index.md#platform-variants for more.   | String | optional | "" |
-| <a id="oci_image_rule-workdir"></a>workdir |  Sets the current working directory of the <code>entrypoint</code> process in the container. This value acts as a default and may be replaced by a working directory specified when creating a container.   | String | optional | "" |
+| <a id="oci_image_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="oci_image_rule-annotations"></a>annotations |  A file containing a dictionary of annotations. Each line should be in the form <code>name=value</code>.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
+| <a id="oci_image_rule-architecture"></a>architecture |  The CPU architecture which the binaries in this image are built to run on. eg: <code>arm64</code>, <code>arm</code>, <code>amd64</code>, <code>s390x</code>. See $GOARCH documentation for possible values: https://go.dev/doc/install/source#environment   | String | optional | <code>""</code> |
+| <a id="oci_image_rule-base"></a>base |  Label to an oci_image target to use as the base.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
+| <a id="oci_image_rule-cmd"></a>cmd |  A file containing a comma separated list to be used as the <code>command & args</code> of the container. These values act as defaults and may be replaced by any specified when creating a container.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
+| <a id="oci_image_rule-entrypoint"></a>entrypoint |  A file containing a comma separated list to be used as the <code>entrypoint</code> to execute when the container starts. These values act as defaults and may be replaced by an entrypoint specified when creating a container.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
+| <a id="oci_image_rule-env"></a>env |  A file containing the default values for the environment variables of the container. These values act as defaults and are merged with any specified when creating a container. Entries replace the base environment variables if any of the entries has conflicting keys. To merge entries with keys specified in the base, <code>${KEY}</code> or <code>$KEY</code> syntax may be used.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
+| <a id="oci_image_rule-labels"></a>labels |  A file containing a dictionary of labels. Each line should be in the form <code>name=value</code>.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
+| <a id="oci_image_rule-os"></a>os |  The name of the operating system which the image is built to run on. eg: <code>linux</code>, <code>windows</code>. See $GOOS documentation for possible values: https://go.dev/doc/install/source#environment   | String | optional | <code>""</code> |
+| <a id="oci_image_rule-tars"></a>tars |  List of tar files to add to the image as layers.         Do not sort this list; the order is preserved in the resulting image.         Less-frequently changed files belong in lower layers to reduce the network bandwidth required to pull and push.<br><br>        The authors recommend [dive](https://github.com/wagoodman/dive) to explore the layering of the resulting image.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
+| <a id="oci_image_rule-user"></a>user |  The <code>username</code> or <code>UID</code> which is a platform-specific structure that allows specific control over which user the process run as. This acts as a default value to use when the value is not specified when creating a container. For Linux based systems, all of the following are valid: <code>user</code>, <code>uid</code>, <code>user:group</code>, <code>uid:gid</code>, <code>uid:group</code>, <code>user:gid</code>. If <code>group/gid</code> is not specified, the default group and supplementary groups of the given <code>user/uid</code> in <code>/etc/passwd</code> from the container are applied.   | String | optional | <code>""</code> |
+| <a id="oci_image_rule-variant"></a>variant |  The variant of the specified CPU architecture. eg: <code>v6</code>, <code>v7</code>, <code>v8</code>. See: https://github.com/opencontainers/image-spec/blob/main/image-index.md#platform-variants for more.   | String | optional | <code>""</code> |
+| <a id="oci_image_rule-workdir"></a>workdir |  Sets the current working directory of the <code>entrypoint</code> process in the container. This value acts as a default and may be replaced by a working directory specified when creating a container.   | String | optional | <code>""</code> |
 
 
-<a id="#oci_image"></a>
+<a id="oci_image"></a>
 
 ## oci_image
 
@@ -98,7 +98,7 @@ Macro wrapper around [oci_image_rule](#oci_image_rule).
 Allows labels and annotations to be provided as a dictionary, in addition to a text file.
 See https://github.com/opencontainers/image-spec/blob/main/annotations.md
 
-Label/annotation/env can by configured using either dict(key->value) or a file that contains key=value pairs
+Label/annotation/env can by configured using either dict(key-&gt;value) or a file that contains key=value pairs
 (one per line). The file can be preprocessed using (e.g. using `jq`) to supply external (potentially not
 deterministic) information when running with `--stamp` flag.  See the example in
 [/examples/labels/BUILD.bazel](https://github.com/bazel-contrib/rules_oci/blob/main/examples/labels/BUILD.bazel).

--- a/docs/image.md
+++ b/docs/image.md
@@ -90,7 +90,7 @@ oci_image(
 ## oci_image
 
 <pre>
-oci_image(<a href="#oci_image-name">name</a>, <a href="#oci_image-labels">labels</a>, <a href="#oci_image-annotations">annotations</a>, <a href="#oci_image-env">env</a>, <a href="#oci_image-cmd">cmd</a>, <a href="#oci_image-entrypoint">entrypoint</a>, <a href="#oci_image-tags">tags</a>, <a href="#oci_image-kwargs">kwargs</a>)
+oci_image(<a href="#oci_image-name">name</a>, <a href="#oci_image-labels">labels</a>, <a href="#oci_image-annotations">annotations</a>, <a href="#oci_image-env">env</a>, <a href="#oci_image-cmd">cmd</a>, <a href="#oci_image-entrypoint">entrypoint</a>, <a href="#oci_image-kwargs">kwargs</a>)
 </pre>
 
 Macro wrapper around [oci_image_rule](#oci_image_rule).
@@ -118,7 +118,6 @@ This is similar to the same-named target created by rules_docker's `container_im
 | <a id="oci_image-env"></a>env |  Environment variables provisioned by default to the running container. See documentation above.   |  <code>None</code> |
 | <a id="oci_image-cmd"></a>cmd |  Command & argument configured by default in the running container. See documentation above.   |  <code>None</code> |
 | <a id="oci_image-entrypoint"></a>entrypoint |  Entrypoint configured by default in the running container. See documentation above.   |  <code>None</code> |
-| <a id="oci_image-tags"></a>tags |  Tags to propagate to targets declared by this macro.   |  <code>[]</code> |
-| <a id="oci_image-kwargs"></a>kwargs |  other named arguments to [oci_image_rule](#oci_image_rule)   |  none |
+| <a id="oci_image-kwargs"></a>kwargs |  other named arguments to [oci_image_rule](#oci_image_rule) and [common rule attributes](https://bazel.build/reference/be/common-definitions#common-attributes).   |  none |
 
 

--- a/docs/image_index.md
+++ b/docs/image_index.md
@@ -2,7 +2,7 @@
 
 Implementation details for oci_image_index rule
 
-<a id="#oci_image_index"></a>
+<a id="oci_image_index"></a>
 
 ## oci_image_index
 
@@ -40,7 +40,7 @@ oci_image_index(
 
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="oci_image_index-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
-| <a id="oci_image_index-images"></a>images |  List of labels to oci_image targets.   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
+| <a id="oci_image_index-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="oci_image_index-images"></a>images |  List of labels to oci_image targets.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
 
 

--- a/docs/pull.md
+++ b/docs/pull.md
@@ -38,7 +38,7 @@ oci_image(
 ```
 
 
-<a id="#oci_pull"></a>
+<a id="oci_pull"></a>
 
 ## oci_pull
 
@@ -52,8 +52,8 @@ To use the resulting image, you can use the `@wkspc` shorthand label, for exampl
 if `name = "distroless_base"`, then you can just use `base = "@distroless_base"`
 in rules like `oci_image`.
 
-> This shorthand syntax is broken on the command-line prior to Bazel 6.2.
-> See https://github.com/bazelbuild/bazel/issues/4385
+&gt; This shorthand syntax is broken on the command-line prior to Bazel 6.2.
+&gt; See https://github.com/bazelbuild/bazel/issues/4385
 
 
 **PARAMETERS**

--- a/docs/push.md
+++ b/docs/push.md
@@ -134,7 +134,7 @@ oci_push(
 ## oci_push
 
 <pre>
-oci_push(<a href="#oci_push-name">name</a>, <a href="#oci_push-remote_tags">remote_tags</a>, <a href="#oci_push-tags">tags</a>, <a href="#oci_push-kwargs">kwargs</a>)
+oci_push(<a href="#oci_push-name">name</a>, <a href="#oci_push-remote_tags">remote_tags</a>, <a href="#oci_push-kwargs">kwargs</a>)
 </pre>
 
 Macro wrapper around [oci_push_rule](#oci_push_rule).
@@ -149,7 +149,6 @@ Allows the remote_tags attribute to be a list of strings in addition to a text f
 | :------------- | :------------- | :------------- |
 | <a id="oci_push-name"></a>name |  name of resulting oci_push_rule   |  none |
 | <a id="oci_push-remote_tags"></a>remote_tags |  a list of tags to apply to the image after pushing, or a label of a file containing tags one-per-line. See [stamped_tags](https://github.com/bazel-contrib/rules_oci/blob/main/examples/push/stamp_tags.bzl) as one example of a way to produce such a file.   |  <code>None</code> |
-| <a id="oci_push-tags"></a>tags |  Tags to propagate to targets declared by this macro.   |  <code>[]</code> |
-| <a id="oci_push-kwargs"></a>kwargs |  other named arguments to [oci_push_rule](#oci_push_rule).   |  none |
+| <a id="oci_push-kwargs"></a>kwargs |  other named arguments to [oci_push_rule](#oci_push_rule) and [common rule attributes](https://bazel.build/reference/be/common-definitions#common-attributes).   |  none |
 
 

--- a/docs/push.md
+++ b/docs/push.md
@@ -8,7 +8,7 @@ load("@rules_oci//oci:defs.bzl", ...)
 ```
 
 
-<a id="#oci_push_rule"></a>
+<a id="oci_push_rule"></a>
 
 ## oci_push_rule
 
@@ -52,7 +52,7 @@ When running the pusher, you can pass flags to `bazel run`.
 
 1. Override `repository` by passing the `-r|--repository` flag.
 
-e.g. `bazel run //myimage:push -- --repository index.docker.io/<ORG>/image`
+e.g. `bazel run //myimage:push -- --repository index.docker.io/&lt;ORG&gt;/image`
 
 2. Supply tags in addition to `remote_tags` by passing the `-t|--tag` flag.
 
@@ -68,7 +68,7 @@ oci_image(name = "image")
 
 oci_push(
     image = ":image",
-    repository = "index.docker.io/<ORG>/image",
+    repository = "index.docker.io/&lt;ORG&gt;/image",
     remote_tags = ["latest"]
 )
 ```
@@ -111,7 +111,7 @@ expand_template(
 
 oci_push(
     image = ":app_image",
-    repository = "ghcr.io/<OWNER>/image",
+    repository = "ghcr.io/&lt;OWNER&gt;/image",
     remote_tags = ":stamped",
 )
 ```
@@ -122,14 +122,14 @@ oci_push(
 
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="oci_push_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
-| <a id="oci_push_rule-image"></a>image |  Label to an oci_image or oci_image_index   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
-| <a id="oci_push_rule-remote_tags"></a>remote_tags |  a .txt file containing tags, one per line.         These are passed to [<code>crane tag</code>](         https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_tag.md)   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
-| <a id="oci_push_rule-repository"></a>repository |  Repository URL where the image will be signed at, e.g.: <code>index.docker.io/&lt;user&gt;/image</code>.         Digests and tags are not allowed.   | String | optional | "" |
-| <a id="oci_push_rule-repository_file"></a>repository_file |  The same as 'repository' but in a file. This allows pushing to different repositories based on stamping.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| <a id="oci_push_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="oci_push_rule-image"></a>image |  Label to an oci_image or oci_image_index   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="oci_push_rule-remote_tags"></a>remote_tags |  a .txt file containing tags, one per line.         These are passed to [<code>crane tag</code>](         https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_tag.md)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
+| <a id="oci_push_rule-repository"></a>repository |  Repository URL where the image will be signed at, e.g.: <code>index.docker.io/&lt;user&gt;/image</code>.         Digests and tags are not allowed.   | String | optional | <code>""</code> |
+| <a id="oci_push_rule-repository_file"></a>repository_file |  The same as 'repository' but in a file. This allows pushing to different repositories based on stamping.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 
 
-<a id="#oci_push"></a>
+<a id="oci_push"></a>
 
 ## oci_push
 

--- a/docs/tarball.md
+++ b/docs/tarball.md
@@ -20,7 +20,7 @@ docker run --rm my-repository:latest
 ```
 
 
-<a id="#oci_tarball"></a>
+<a id="oci_tarball"></a>
 
 ## oci_tarball
 
@@ -38,8 +38,8 @@ Passing anything other than oci_image to the image attribute will lead to build 
 
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="oci_tarball-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
-| <a id="oci_tarball-image"></a>image |  Label of a directory containing an OCI layout, typically <code>oci_image</code>   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
-| <a id="oci_tarball-repo_tags"></a>repo_tags |  a file containing repo_tags, one per line.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| <a id="oci_tarball-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="oci_tarball-image"></a>image |  Label of a directory containing an OCI layout, typically <code>oci_image</code>   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="oci_tarball-repo_tags"></a>repo_tags |  a file containing repo_tags, one per line.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 
 

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -50,12 +50,13 @@ def rules_oci_internal_deps():
         urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-gazelle-plugin-1.4.1.tar.gz"],
     )
 
+
     http_archive(
         name = "io_bazel_stardoc",
-        sha256 = "c9794dcc8026a30ff67cf7cf91ebe245ca294b20b071845d12c192afe243ad72",
+        sha256 = "dfbc364aaec143df5e6c52faf1f1166775a5b4408243f445f44b661cfdc3134f",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/stardoc/releases/download/0.5.0/stardoc-0.5.0.tar.gz",
-            "https://github.com/bazelbuild/stardoc/releases/download/0.5.0/stardoc-0.5.0.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/stardoc/releases/download/0.5.6/stardoc-0.5.6.tar.gz",
+            "https://github.com/bazelbuild/stardoc/releases/download/0.5.6/stardoc-0.5.6.tar.gz",
         ],
     )
 

--- a/oci/defs.bzl
+++ b/oci/defs.bzl
@@ -9,6 +9,7 @@ load("@rules_oci//oci:defs.bzl", ...)
 load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@aspect_bazel_lib//lib:directory_path.bzl", "directory_path")
 load("@aspect_bazel_lib//lib:jq.bzl", "jq")
+load("@aspect_bazel_lib//lib:utils.bzl", "propagate_common_rule_attributes")
 load("@bazel_skylib//lib:types.bzl", "types")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("//oci/private:image.bzl", _oci_image = "oci_image")
@@ -21,7 +22,7 @@ oci_image_rule = _oci_image
 oci_image_index = _oci_image_index
 oci_push_rule = _oci_push
 
-def oci_image(name, labels = None, annotations = None, env = None, cmd = None, entrypoint = None, tags = [], **kwargs):
+def oci_image(name, labels = None, annotations = None, env = None, cmd = None, entrypoint = None, **kwargs):
     """Macro wrapper around [oci_image_rule](#oci_image_rule).
 
     Allows labels and annotations to be provided as a dictionary, in addition to a text file.
@@ -42,16 +43,18 @@ def oci_image(name, labels = None, annotations = None, env = None, cmd = None, e
         env: Environment variables provisioned by default to the running container. See documentation above.
         cmd: Command & argument configured by default in the running container. See documentation above.
         entrypoint: Entrypoint configured by default in the running container. See documentation above.
-        tags: Tags to propagate to targets declared by this macro.
-        **kwargs: other named arguments to [oci_image_rule](#oci_image_rule)
+        **kwargs: other named arguments to [oci_image_rule](#oci_image_rule) and
+            [common rule attributes](https://bazel.build/reference/be/common-definitions#common-attributes).
     """
+    forwarded_kwargs = propagate_common_rule_attributes(kwargs)
+
     if types.is_dict(annotations):
         annotations_label = "_{}_write_annotations".format(name)
         write_file(
             name = annotations_label,
             out = "_{}.annotations.txt".format(name),
             content = ["{}={}".format(key, value) for (key, value) in annotations.items()],
-            tags = tags,
+            **forwarded_kwargs,
         )
         annotations = annotations_label
 
@@ -61,7 +64,7 @@ def oci_image(name, labels = None, annotations = None, env = None, cmd = None, e
             name = labels_label,
             out = "_{}.labels.txt".format(name),
             content = ["{}={}".format(key, value) for (key, value) in labels.items()],
-            tags = tags,
+            **forwarded_kwargs,
         )
         labels = labels_label
 
@@ -71,7 +74,7 @@ def oci_image(name, labels = None, annotations = None, env = None, cmd = None, e
             name = env_label,
             out = "_{}.env.txt".format(name),
             content = ["{}={}".format(key, value) for (key, value) in env.items()],
-            tags = tags,
+            **forwarded_kwargs,
         )
         env = env_label
 
@@ -81,7 +84,7 @@ def oci_image(name, labels = None, annotations = None, env = None, cmd = None, e
             name = env_label,
             out = "_{}.env.txt".format(name),
             content = ["{}={}".format(key, value) for (key, value) in env.items()],
-            tags = tags,
+            **forwarded_kwargs,
         )
         env = env_label
 
@@ -91,7 +94,7 @@ def oci_image(name, labels = None, annotations = None, env = None, cmd = None, e
             name = cmd_label,
             out = "_{}.cmd.txt".format(name),
             content = [",".join(cmd)],
-            tags = tags,
+            **forwarded_kwargs,
         )
         cmd = cmd_label
 
@@ -101,7 +104,7 @@ def oci_image(name, labels = None, annotations = None, env = None, cmd = None, e
             name = entrypoint_label,
             out = "_{}.entrypoint.txt".format(name),
             content = [",".join(entrypoint)],
-            tags = tags,
+            **forwarded_kwargs,
         )
         entrypoint = entrypoint_label
 
@@ -112,7 +115,6 @@ def oci_image(name, labels = None, annotations = None, env = None, cmd = None, e
         env = env,
         cmd = cmd,
         entrypoint = entrypoint,
-        tags = tags,
         **kwargs
     )
 
@@ -122,14 +124,14 @@ def oci_image(name, labels = None, annotations = None, env = None, cmd = None, e
         name = "_{}_index_json".format(name),
         directory = name,
         path = "index.json",
-        tags = tags,
+        **forwarded_kwargs,
     )
 
     copy_file(
         name = "_{}_index_json_cp".format(name),
         src = "_{}_index_json".format(name),
         out = "_{}_index.json".format(name),
-        tags = tags,
+        **forwarded_kwargs,
     )
 
     # Matches the [name].digest target produced by rules_docker container_image
@@ -139,10 +141,10 @@ def oci_image(name, labels = None, annotations = None, env = None, cmd = None, e
         srcs = ["_{}_index.json".format(name)],
         filter = """.manifests[0].digest""",
         out = name + ".json.sha256",  # path chosen to match rules_docker for easy migration
-        tags = tags,
+        **forwarded_kwargs,
     )
 
-def oci_push(name, remote_tags = None, tags = [], **kwargs):
+def oci_push(name, remote_tags = None, **kwargs):
     """Macro wrapper around [oci_push_rule](#oci_push_rule).
 
     Allows the remote_tags attribute to be a list of strings in addition to a text file.
@@ -153,27 +155,28 @@ def oci_push(name, remote_tags = None, tags = [], **kwargs):
             or a label of a file containing tags one-per-line.
             See [stamped_tags](https://github.com/bazel-contrib/rules_oci/blob/main/examples/push/stamp_tags.bzl)
             as one example of a way to produce such a file.
-        tags: Tags to propagate to targets declared by this macro.
-        **kwargs: other named arguments to [oci_push_rule](#oci_push_rule).
+        **kwargs: other named arguments to [oci_push_rule](#oci_push_rule) and
+            [common rule attributes](https://bazel.build/reference/be/common-definitions#common-attributes).
     """
+    forwarded_kwargs = propagate_common_rule_attributes(kwargs)
+
     if types.is_list(remote_tags):
         tags_label = "_{}_write_tags".format(name)
         write_file(
             name = tags_label,
             out = "_{}.tags.txt".format(name),
             content = remote_tags,
-            tags = tags,
+            **forwarded_kwargs,
         )
         remote_tags = tags_label
 
     oci_push_rule(
         name = name,
         remote_tags = remote_tags,
-        tags = tags,
         **kwargs
     )
 
-def oci_tarball(name, repo_tags = None, tags = [], **kwargs):
+def oci_tarball(name, repo_tags = None, **kwargs):
     """Macro wrapper around [oci_tarball_rule](#oci_tarball_rule).
 
     Allows the repo_tags attribute to be a list of strings in addition to a text file.
@@ -184,22 +187,23 @@ def oci_tarball(name, repo_tags = None, tags = [], **kwargs):
             or a label of a file containing tags one-per-line.
             See [stamped_tags](https://github.com/bazel-contrib/rules_oci/blob/main/examples/push/stamp_tags.bzl)
             as one example of a way to produce such a file.
-        tags: Tags to propagate to targets declared by this macro.
-        **kwargs: other named arguments to [oci_tarball_rule](#oci_tarball_rule).
+        **kwargs: other named arguments to [oci_tarball_rule](#oci_tarball_rule) and
+            [common rule attributes](https://bazel.build/reference/be/common-definitions#common-attributes).
     """
+    forwarded_kwargs = propagate_common_rule_attributes(kwargs)
+
     if types.is_list(repo_tags):
         tags_label = "_{}_write_tags".format(name)
         write_file(
             name = tags_label,
             out = "_{}.tags.txt".format(name),
             content = repo_tags,
-            tags = tags,
+            **forwarded_kwargs,
         )
         repo_tags = tags_label
 
     oci_tarball_rule(
         name = name,
         repo_tags = repo_tags,
-        tags = tags,
         **kwargs
     )

--- a/oci/dependencies.bzl
+++ b/oci/dependencies.bzl
@@ -29,7 +29,7 @@ def rules_oci_dependencies():
 
     http_archive(
         name = "aspect_bazel_lib",
-        sha256 = "f1c181b910f821072f38ee45bb87db6b56275458c7f832c54c54ba6334119eca",
-        strip_prefix = "bazel-lib-1.32.0",
-        url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.32.0/bazel-lib-v1.32.0.tar.gz",
+        sha256 = "e9505bd956da64b576c433e4e41da76540fd8b889bbd17617fe480a646b1bfb9",
+        strip_prefix = "bazel-lib-1.35.0",
+        url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.35.0/bazel-lib-v1.35.0.tar.gz",
     )


### PR DESCRIPTION
Picked this up from  #370. We needed to update stardoc in the workspace to match the bazel-lib bzlmod stardoc version so that outputs are identical. 