### PR TITLE
refactor: update zot and use minimal binaries

### DIFF
--- a/oci/private/image.sh.tpl
+++ b/oci/private/image.sh.tpl
@@ -81,8 +81,9 @@ EOF
 
 # this will redirect stderr(2) to stderr file.
 {
-source "${REGISTRY_LAUNCHER}"
-readonly REGISTRY=$(start_registry "${STORAGE_DIR}" "${STDERR}")
+source "${REGISTRY_LAUNCHER}" 
+REGISTRY=
+REGISTRY=$(start_registry "${STORAGE_DIR}" "${STDERR}")
 
 OUTPUT=""
 WORKDIR=""

--- a/oci/private/registry/zot_launcher.sh.tpl
+++ b/oci/private/registry/zot_launcher.sh.tpl
@@ -15,7 +15,7 @@ function start_registry() {
     "log": { "level": "info" }
 }
 EOF
-    "${ZOT}" serve "${config_path}" >> $output 2>&1 &
+    HOME="${TMPDIR}" "${ZOT}" serve "${config_path}" >> $output 2>&1 &
 
     local timeout=$((SECONDS+${deadline}))
 

--- a/oci/private/versions.bzl
+++ b/oci/private/versions.bzl
@@ -42,10 +42,12 @@ CRANE_VERSIONS = {
 }
 
 ZOT_VERSIONS = {
-  "v2.0.0-rc6": {
-    "darwin-amd64": "sha256-xhVEtIP5XnTsf2VaRZLCENtKccMMuBUZT74QLNgrPzE=",
-    "darwin-arm64": "sha256-/Xt3lh+34kSLb/Uz97pUrjbNjwpBQZHTE1UYdeaY1Bo=",
-    "linux-amd64": "sha256-qAfQrNAzkCRYXcZcL7zGUbhpXGz1v0os2Zk2teJC43U=",
-    "linux-arm64": "sha256-41aPaoiSB0/kHNepRWpEURYIHMEtcNo6LJh7vhL/XqY="
+  "v2.0.0-rc7": {
+    "darwin-amd64": "sha256-CgQgQBbT2MDf9H9ttWZXSCP1SJfHvI1U1JX8WcExsqc=",
+    "darwin-arm64": "sha256-z+7Tn1mhAfvx9JlAeMq2WxtpMx6lcLjvycUhSAANX1U=",
+    "freebsd-amd64": "sha256-ex4IzW3299cegSnW2Q4LCk/sBJfaIPIxzujo1ocWnRY=",
+    "freebsd-arm64": "sha256-byEVM7MsYNNfC94bmqxCG+VyP1CoMVPQgfQEyVQro7M=",
+    "linux-amd64": "sha256-pAiaOvyD+Tvi/d6MGAFytJFmYYttCukucxaxbAmnX5w=",
+    "linux-arm64": "sha256-+TLMTCs+eYPmxWAbbvb2PFNwGvHsMI40yxeY3wVGepM="
   }
 }

--- a/oci/private/versions.bzl
+++ b/oci/private/versions.bzl
@@ -42,10 +42,10 @@ CRANE_VERSIONS = {
 }
 
 ZOT_VERSIONS = {
-    "v1.4.3-rc3": {
-        "darwin-amd64": "sha256-AGyGP/DKR5QCrcdzB7P6TjBEAMNMPG0nmY/eUcmxH3I=",
-        "darwin-arm64": "sha256-C7uoK2STgfq9XXXHLSLKu3Fs8XmX94bIb0RHpwoqjzk=",
-        "linux-amd64": "sha256-BdeBe7bBOYCy/VfRHZsz7EC+7b4TC+kSa0g7CI1HKd0=",
-        "linux-arm64": "sha256-57DAO3f8h5ZV3w6zH+nXsD6KpnJI5crywbksLri4RHE=",
-    },
+  "v2.0.0-rc6": {
+    "darwin-amd64": "sha256-xhVEtIP5XnTsf2VaRZLCENtKccMMuBUZT74QLNgrPzE=",
+    "darwin-arm64": "sha256-/Xt3lh+34kSLb/Uz97pUrjbNjwpBQZHTE1UYdeaY1Bo=",
+    "linux-amd64": "sha256-qAfQrNAzkCRYXcZcL7zGUbhpXGz1v0os2Zk2teJC43U=",
+    "linux-arm64": "sha256-41aPaoiSB0/kHNepRWpEURYIHMEtcNo6LJh7vhL/XqY="
+  }
 }

--- a/oci/repositories.bzl
+++ b/oci/repositories.bzl
@@ -70,7 +70,7 @@ registry_toolchain(
 
 def _zot_repo_impl(repository_ctx):
     platform = repository_ctx.attr.platform.replace("_", "-")
-    url = "https://github.com/project-zot/zot/releases/download/{version}/zot-{platform}".format(
+    url = "https://github.com/project-zot/zot/releases/download/{version}/zot-{platform}-minimal".format(
         version = repository_ctx.attr.zot_version,
         platform = platform,
     )

--- a/scripts/mirror_releases_zot.sh
+++ b/scripts/mirror_releases_zot.sh
@@ -6,8 +6,8 @@ JQ_FILTER=\
 'map({
     "key": .tag_name, 
     "value": .assets 
-        | map( select( (.name | startswith("zot-")) and (.name | endswith("-debug") | not) and (.name | endswith("-minimal") | not) ) )
-        | map({ key: .name | ltrimstr("zot-"), value: "sha256-" })
+        | map( select( (.name | startswith("zot-")) and (.name | endswith("-debug") | not) and (.name | endswith("-minimal") ) ) )
+        | map({ key: .name | ltrimstr("zot-") | rtrimstr("-minimal"), value: "sha256-" })
         | from_entries 
 }) | from_entries
 '
@@ -20,7 +20,7 @@ INFO="$(curl --silent -H "Accept: application/vnd.github.v3+json" https://api.gi
 # TODO: remove this for loop once https://github.com/project-zot/zot/issues/715 is fixed.
 for VERSION in $(jq -r 'keys | join("\n")' <<< $INFO); do 
     for PLATFORM in $(jq -r ".[\"$VERSION\"] | keys | join(\"\n\")" <<< $INFO); do 
-        SHA256=$(curl -fLs "https://github.com/project-zot/zot/releases/download/$VERSION/zot-$PLATFORM" | sha256sum | xxd -r -p | base64)
+        SHA256=$(curl -fLs "https://github.com/project-zot/zot/releases/download/$VERSION/zot-$PLATFORM" | shasum -a 256 | xxd -r -p | base64)
         INFO=$(jq ".[\"$VERSION\"][\"$PLATFORM\"] = \"sha256-$SHA256\"" <<< $INFO)
     done
 done

--- a/scripts/mirror_releases_zot.sh
+++ b/scripts/mirror_releases_zot.sh
@@ -20,7 +20,7 @@ INFO="$(curl --silent -H "Accept: application/vnd.github.v3+json" https://api.gi
 # TODO: remove this for loop once https://github.com/project-zot/zot/issues/715 is fixed.
 for VERSION in $(jq -r 'keys | join("\n")' <<< $INFO); do 
     for PLATFORM in $(jq -r ".[\"$VERSION\"] | keys | join(\"\n\")" <<< $INFO); do 
-        SHA256=$(curl -fLs "https://github.com/project-zot/zot/releases/download/$VERSION/zot-$PLATFORM" | shasum -a 256 | xxd -r -p | base64)
+        SHA256=$(curl -fLs "https://github.com/project-zot/zot/releases/download/$VERSION/zot-$PLATFORM-minimal" | shasum -a 256 | xxd -r -p | base64)
         INFO=$(jq ".[\"$VERSION\"][\"$PLATFORM\"] = \"sha256-$SHA256\"" <<< $INFO)
     done
 done


### PR DESCRIPTION
Updates zot to the latest release and switches to minimal binaries for smaller and faster builds. 