### PR TITLE
refactor: simplify repotags processing

### DIFF
--- a/oci/private/tarball.sh.tpl
+++ b/oci/private/tarball.sh.tpl
@@ -6,7 +6,7 @@ readonly YQ="{{yq}}"
 readonly IMAGE_DIR="{{image_dir}}"
 readonly BLOBS_DIR="${STAGING_DIR}/blobs"
 readonly TARBALL_PATH="{{tarball_path}}"
-readonly TAGS_FILE="{{tags}}"
+readonly REPOTAGS=($(cat "{{tags}}"))
 
 MANIFEST_DIGEST=$(${YQ} eval '.manifests[0].digest | sub(":"; "/")' "${IMAGE_DIR}/index.json" | tr  -d '"')
 MANIFEST_BLOB_PATH="${IMAGE_DIR}/blobs/${MANIFEST_DIGEST}"
@@ -23,15 +23,11 @@ for LAYER in $(${YQ} ".[]" <<< $LAYERS); do
     cp -f "${IMAGE_DIR}/blobs/${LAYER}" "${BLOBS_DIR}/${LAYER}.tar.gz"
 done
 
-# Replace newlines (unix or windows line endings) with % character.
-# We can't pass newlines to yq due to https://github.com/mikefarah/yq/issues/1430 and
-# we can't update YQ at the moment because structure_test depends on a specific version:
-# see https://github.com/bazel-contrib/rules_oci/issues/212
-repo_tags="$(tr -d '\r' < "${TAGS_FILE}" | tr '\n' '%')" \
+repo_tags="${REPOTAGS[@]}" \
 config="blobs/${CONFIG_DIGEST}" \
 layers="${LAYERS}" \
 "${YQ}" eval \
-        --null-input '.[0] = {"Config": env(config), "RepoTags": "${repo_tags}" | envsubst | split("%") | map(select(. != "")) , "Layers": env(layers) | map( "blobs/" + . + ".tar.gz") }' \
+        --null-input '.[0] = {"Config": env(config), "RepoTags": "${repo_tags}" | envsubst | split(" ") | map(select(. != "")) , "Layers": env(layers) | map( "blobs/" + . + ".tar.gz") }' \
         --output-format json > "${STAGING_DIR}/manifest.json"
 
 # TODO: https://github.com/bazel-contrib/rules_oci/issues/217


### PR DESCRIPTION
Rather than doing a bunch of replacements, use bash builtins of array parsing and array stringifying.