### PR TITLE
fix: fixed go and rust doc 

### DIFF
--- a/docs/go.md
+++ b/docs/go.md
@@ -78,14 +78,9 @@ load("@rules_oci//oci:defs.bzl", "oci_image")
 
 oci_image(
     name = "image",
-    architecture = select({
-        "@platforms//cpu:arm64": "arm64",
-        "@platforms//cpu:x86_64": "amd64",
-    }),
     base = "@distroless_base",
     tars = [":tar"],
     entrypoint = ["/app"],
-    os = "linux",
 )
 ```
 

--- a/docs/rust.md
+++ b/docs/rust.md
@@ -143,14 +143,9 @@ load("@rules_oci//oci:defs.bzl", "oci_image")
 # Step 3: Build image and add built layer to it
 oci_image(
     name = "hello_image",
-    architecture = select({
-        "@platforms//cpu:arm64": "arm64",
-        "@platforms//cpu:x86_64": "amd64",
-    }),
     base = "@distroless_cc",
     tars = [":hello_bin_layer"],
     entrypoint = ["/hello_bin"],
-    os = "linux",
 )
 
 ```
@@ -186,13 +181,8 @@ pkg_tar(
 # Step 3: Build image and add built layer to it
 oci_image(
     name = "hello_image",
-    architecture = select({
-        "@platforms//cpu:arm64": "arm64",
-        "@platforms//cpu:x86_64": "amd64",
-    }),
     base = "@distroless_cc",
     tars = [":hello_bin_layer"],
     entrypoint = ["/hello_bin"],
-    os = "linux",
 )
 ```


### PR DESCRIPTION
If I understand correctly, `architecture` and `os` cannot be specified when using a base image. It appears that rust and go documentation are outdated. This PR attempts to fix this discrepancy.