### PR TITLE
fix: remove workaround for missing crane workdir support

### DIFF
--- a/e2e/crane_as_registry/BUILD.bazel
+++ b/e2e/crane_as_registry/BUILD.bazel
@@ -12,6 +12,7 @@ oci_image(
         "--arg2",
     ],
     entrypoint = ["/custom_bin"],
+    workdir = "/custom_dir",
     env = {
         "ENV": "/test",
     },

--- a/oci/private/image.sh.tpl
+++ b/oci/private/image.sh.tpl
@@ -95,7 +95,7 @@ for ARG in "$@"; do
         (oci:empty_base) FIXED_ARGS+=("$(empty_base $REGISTRY $@)") ;;
         (oci:layout*) FIXED_ARGS+=("$(base_from_layout ${ARG/oci:layout\/} $REGISTRY)") ;;
         (--output=*) OUTPUT="${ARG#--output=}" ;;
-        (--workdir=*) WORKDIR="${ARG#--workdir=}" ;;
+        (--workdir=*) FIXED_ARGS+=("$ARG") ;;
         (--env-file=*)
           # NB: the '|| [-n $in]' expression is needed to process the final line, in case the input
           # file doesn't have a trailing newline.
@@ -153,11 +153,6 @@ if [ ${#ENV_EXPANSIONS[@]} -ne 0 ]; then
         environment_args+=( --env "${key}=${value_from_base}" )
     done
     REF=$("${CRANE}" mutate "${REF}" ${environment_args[@]})
-fi
-
-# TODO: https://github.com/google/go-containerregistry/issues/1515
-if [ -n "${WORKDIR}" ]; then 
-    REF=$("${CRANE}" config "${REF}" | "${JQ}"  --arg workdir "${WORKDIR}" '.config.WorkingDir = $workdir' | "${CRANE}" edit config "${REF}")
 fi
 
 if [ -n "$OUTPUT" ]; then


### PR DESCRIPTION
Support got added
https://github.com/google/go-containerregistry/pull/1615

Discovered while working on #220.