### PR TITLE
Update crane and zot versions in MODULE.bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,10 +11,14 @@ bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "platforms", version = "0.0.5")
 
 oci = use_extension("//oci:extensions.bzl", "oci")
-oci.toolchains(crane_version = "v0.14.0")
-use_repo(oci, "oci_auth_config", "oci_crane_registry_toolchains", "oci_crane_toolchains")
+oci.toolchains(
+    # Keep in sync with oci/private/versions.bzl.
+    crane_version = "v0.15.2",
+    zot_version = "v1.4.3-rc3",
+)
+use_repo(oci, "oci_auth_config", "oci_crane_toolchains", "oci_zot_toolchains")
 
-register_toolchains("@oci_crane_toolchains//:all", "@oci_crane_registry_toolchains//:all")
+register_toolchains("@oci_crane_toolchains//:all", "@oci_zot_toolchains//:all")
 
 bazel_dep(name = "rules_pkg", version = "0.7.0", dev_dependency = True)
 bazel_dep(name = "gazelle", version = "0.29.0", dev_dependency = True, repo_name = "bazel_gazelle")

--- a/oci/private/versions.bzl
+++ b/oci/private/versions.bzl
@@ -1,5 +1,7 @@
 "Mirror of release info"
 
+# Also update latest version in MODULE.bazel when adding a new version.
+
 # WARNING: only v0.12.0 and above is supported.
 CRANE_VERSIONS = {
     "v0.15.2": {


### PR DESCRIPTION
This makes it consistent with WORKSPACE, and also enables the use of zot
for bzlmod users.

Related issue: #410.
