### PR TITLE
fix: make crane use storage directory

### DIFF
--- a/oci/private/registry/crane_launcher.sh.tpl
+++ b/oci/private/registry/crane_launcher.sh.tpl
@@ -2,10 +2,14 @@ readonly SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
 readonly CRANE_REGISTRY_BIN="${SCRIPT_DIR}/{{CRANE}}"
 
 function start_registry() {
-    local __unused_storage_dir="$1"
+    local storage_dir="$1"
     local output="$2"
     local deadline="${3:-5}"
 
+    mkdir -p "${storage_dir}"
+    # --blobs-to-disk uses go's os.TempDir() function which is equal to TMPDIR under *nix.
+    # https://pkg.go.dev/os#TempDir
+    TMPDIR="${storage_dir}" TMP="${storage_dir}" \
     "${CRANE_REGISTRY_BIN}" registry serve --blobs-to-disk >> $output 2>&1 &
 
     local timeout=$((SECONDS+${deadline}))


### PR DESCRIPTION
So that no blobs are left over at /tmp. bazel automatically discards undeclared outputs, which will make the cleanup out of band for performance reasons. With #324 we will make use storage dir for further performance improvement.