### PR TITLE
feat: bump and assert crane version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,7 +11,7 @@ bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "platforms", version = "0.0.5")
 
 oci = use_extension("//oci:extensions.bzl", "oci")
-oci.toolchains(crane_version = "v0.16.1")
+oci.toolchains(crane_version = "v0.17.0")
 use_repo(oci, "oci_auth_config", "oci_crane_registry_toolchains", "oci_crane_toolchains")
 
 register_toolchains("@oci_crane_toolchains//:all", "@oci_crane_registry_toolchains//:all")

--- a/oci/private/BUILD.bazel
+++ b/oci/private/BUILD.bazel
@@ -96,5 +96,6 @@ bzl_library(
 bzl_library(
     name = "util",
     srcs = ["util.bzl"],
+    deps = ["@bazel_skylib//lib:versions"],
     visibility = ["//oci:__subpackages__"],
 )

--- a/oci/private/image.bzl
+++ b/oci/private/image.bzl
@@ -85,11 +85,6 @@ If `group/gid` is not specified, the default group and supplementary groups of t
     "_empty_tar": attr.label(default = "empty.tar", allow_single_file = True),
 }
 
-def _format_string_to_string_tuple(kv):
-    if type(kv) != "tuple":
-        fail("argument `kv` must be a tuple.")
-    return "%s=%s" % kv
-
 def _platform_str(os, arch, variant = None):
     parts = [os, arch]
     if variant:
@@ -104,9 +99,12 @@ def _oci_image_impl(ctx):
     if ctx.attr.base and (ctx.attr.os or ctx.attr.architecture or ctx.attr.variant):
         fail("'os', 'architecture' and 'variant' come from the image provided by 'base' and cannot be overridden.")
 
+    util.assert_crane_version_at_least(ctx, "0.15.1", "oci_image")
+
     crane = ctx.toolchains["@rules_oci//oci:crane_toolchain_type"]
     registry = ctx.toolchains["@rules_oci//oci:registry_toolchain_type"]
     jq = ctx.toolchains["@aspect_bazel_lib//lib:jq_toolchain_type"]
+    
 
     launcher = ctx.actions.declare_file("image_%s.sh" % ctx.label.name)
 

--- a/oci/private/util.bzl
+++ b/oci/private/util.bzl
@@ -1,4 +1,5 @@
 """Utilities"""
+load("@bazel_skylib//lib:versions.bzl", "versions")
 
 def _parse_image(image):
     """Support syntax sugar in oci_pull where multiple data fields are in a single string, "image"
@@ -154,6 +155,12 @@ def _build_manifest_json(media_type, size, digest, platform):
         optional_platform = optional_platform
     )
 
+def _assert_crane_version_at_least(ctx, at_least, rule):
+    toolchain = ctx.toolchains["@rules_oci//oci:crane_toolchain_type"]
+    if not versions.is_at_least(at_least, toolchain.crane_info.version):
+        fail("rule {} requires crane version >={}".format(rule, at_least))
+
+
 util = struct(
     parse_image = _parse_image,
     sha256 = _sha256,
@@ -161,4 +168,5 @@ util = struct(
     maybe_wrap_launcher_for_windows = _maybe_wrap_launcher_for_windows,
     file_exists = _file_exists,
     build_manifest_json = _build_manifest_json,
+    assert_crane_version_at_least = _assert_crane_version_at_least
 )

--- a/oci/private/versions.bzl
+++ b/oci/private/versions.bzl
@@ -2,6 +2,20 @@
 
 # WARNING: only v0.15.1 and above is supported due to --workdir feature.
 CRANE_VERSIONS = {
+    "v0.17.0": {
+        "go-containerregistry-0": "sha256-d54x77NFqxSOlIQuk2D+BOBFAw8w5hXhOQQcuF0zLsk=",
+        "darwin_arm64": "sha256-pYM/Dh0C0pnT71cv0f+qFgZE65la5Nuvi8gEFdEVnoo=",
+        "darwin_x86_64": "sha256-yIaqqLuR2RD1G3HscYukk0n2/wn84CAec+p6lYNA4FY=",
+        "linux_arm64": "sha256-JHTVYComLxMx2JVVjnByN38/iTX6q2HBtFweqHD0F6c=",
+        "linux_armv6": "sha256-AWVqUDWJ1h3u8xWn8u7Na1O7SRi8lwPFWdpnyErCa3o=",
+        "linux_i386": "sha256-+0fF8Q9jWOk0q4Xsv0Da+LKEsU+nwAEOiA91+SPMfMA=",
+        "linux_ppc64le": "sha256-nwqKvxy4JHzRoekgeTVMGfd/X8CiuOtYty/6w//gGvU=",
+        "linux_s390x": "sha256-fWnvl6iGsIaP3YJeQxwfco2ze8ZpTgF2jAgGXTgDcoU=",
+        "linux_x86_64": "sha256-G00+4eIUd2vXS4h0HM8bBw6O1WYAVvBa9jKho5n+IcY=",
+        "windows_arm64": "sha256-OdP9MOp/3HwIOjB0WdPY1bnLkLD2XzR3RS90HK5EyJs=",
+        "windows_armv6": "sha256-c8OHU6DKiYE+ZTG32RTY9Nn7t7RaPVS/MXshGiAmkXc=",
+        "windows_x86_64": "sha256-NyebS5afExgDW5rTAEsysws6D3ruBJeqZfJeW0b7rU8="
+    },
     "v0.16.1": {
         "go-containerregistry-0": "sha256-KHa1NgQVE4cW1YN6aeHBFhgOSOz2KmP1MBw1HVoS+Zs=",
         "darwin_arm64": "sha256-OgSfRI2SluHc01ZsWALiQbzU4Yc/mYoSKCRlXiDg10Q=",

--- a/oci/repositories.bzl
+++ b/oci/repositories.bzl
@@ -15,7 +15,8 @@ load("@rules_oci//oci:toolchain.bzl", "crane_toolchain")
 
 crane_toolchain(
     name = "crane_toolchain", 
-    crane = "{binary}"
+    crane = "{binary}",
+    version = "{version}"
 )
 
 registry_toolchain(
@@ -45,7 +46,10 @@ def _crane_repo_impl(repository_ctx):
     )
     repository_ctx.file(
         "BUILD.bazel",
-        CRANE_BUILD_TMPL.format(binary = binary),
+        CRANE_BUILD_TMPL.format(
+            binary = binary,
+            version = repository_ctx.attr.crane_version
+        ),
     )
 
 crane_repositories = repository_rule(

--- a/oci/toolchain.bzl
+++ b/oci/toolchain.bzl
@@ -4,6 +4,7 @@ CraneInfo = provider(
     doc = "Information about how to invoke the crane executable.",
     fields = {
         "binary": "Executable crane binary",
+        "version": "Crane version"
     },
 )
 
@@ -16,7 +17,10 @@ def _crane_toolchain_impl(ctx):
         files = depset([binary]),
         runfiles = ctx.runfiles(files = [binary]),
     )
-    crane_info = CraneInfo(binary = binary)
+    crane_info = CraneInfo(
+        binary = binary,
+        version = ctx.attr.version.removeprefix("v")
+    )
     toolchain_info = platform_common.ToolchainInfo(
         crane_info = crane_info,
         template_variables = template_variables,
@@ -38,6 +42,7 @@ crane_toolchain = rule(
             executable = True,
             cfg = "exec",
         ),
+        "version": attr.string(mandatory = True, doc = "Version of the crane binary")
     },
     doc = "Defines a crane toolchain. See: https://docs.bazel.build/versions/main/toolchains.html#defining-toolchains.",
 )


### PR DESCRIPTION
bumps crane version to `0.17.0` and introduces a check to prevent confusing messages