### PR TITLE
perf: use hardlink

### DIFF
--- a/oci/private/pull.bzl
+++ b/oci/private/pull.bzl
@@ -330,6 +330,8 @@ load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 copy_to_directory(
     name = "{target_name}",
     out = "layout",
+    # Always use hardlink to avoid having copies of the blobs from external repository in the output-tree.
+    hardlink = "on",
     include_external_repositories = ["*"],
     srcs = [
         "blobs",


### PR DESCRIPTION
This avoid having two copies of blobs in the external repository.  

Part of #439