### PR TITLE
support passing label as container cli tool to bazel run //my/tarball

### DIFF
--- a/docs/tarball.md
+++ b/docs/tarball.md
@@ -25,7 +25,7 @@ docker run --rm my-repository:latest
 ## oci_tarball
 
 <pre>
-oci_tarball(<a href="#oci_tarball-name">name</a>, <a href="#oci_tarball-format">format</a>, <a href="#oci_tarball-image">image</a>, <a href="#oci_tarball-repo_tags">repo_tags</a>)
+oci_tarball(<a href="#oci_tarball-name">name</a>, <a href="#oci_tarball-command">command</a>, <a href="#oci_tarball-format">format</a>, <a href="#oci_tarball-image">image</a>, <a href="#oci_tarball-repo_tags">repo_tags</a>)
 </pre>
 
 Creates tarball from OCI layouts that can be loaded into docker daemon without needing to publish the image first.
@@ -39,6 +39,7 @@ Passing anything other than oci_image to the image attribute will lead to build 
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="oci_tarball-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="oci_tarball-command"></a>command |  target for a container cli tool (i.e. docker or podman or other) that will be used to load the image into the local engine when using 'bazel run //my/image'.",   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 | <a id="oci_tarball-format"></a>format |  Format of image to generate. Options are: docker, oci. Currently, when the input image is an image_index, only oci is supported, and when the input image is an image, only docker is supported. Conversions between formats may be supported in the future.   | String | optional | <code>"docker"</code> |
 | <a id="oci_tarball-image"></a>image |  Label of a directory containing an OCI layout, typically <code>oci_image</code>   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 | <a id="oci_tarball-repo_tags"></a>repo_tags |  a file containing repo_tags, one per line.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |

--- a/oci/private/tarball.bzl
+++ b/oci/private/tarball.bzl
@@ -39,7 +39,7 @@ attrs = {
         allow_single_file = [".txt"],
         mandatory = True,
     ),
-    "container_cli_tool": attr.label(
+    "command": attr.label(
         doc = """\
             target for a container cli tool (i.e. docker or podman or other) that will be used to load the image into the local engine when using 'bazel run //my/image'.",
             """,
@@ -99,13 +99,13 @@ def _tarball_impl(ctx):
         output = exe,
         substitutions = {
             "{{image_path}}": tarball.short_path,
-            "{{container_cli_tool}}": ctx.file.container_cli_tool.path if ctx.file.container_cli_tool else "",
+            "{{command}}": ctx.file.command.path if ctx.file.command else "",
         },
         is_executable = True,
     )
     runfiles = [tarball]
-    if ctx.file.container_cli_tool:
-        runfiles.append(ctx.file.container_cli_tool)
+    if ctx.file.command:
+        runfiles.append(ctx.file.command)
 
     return [
         DefaultInfo(files = depset([tarball]), runfiles = ctx.runfiles(files = runfiles), executable = exe),

--- a/oci/private/tarball_run.sh.tpl
+++ b/oci/private/tarball_run.sh.tpl
@@ -10,7 +10,7 @@ elif command -v podman &> /dev/null; then
     CONTAINER_CLI="podman"
 else
     echo >&2 "Neither docker or podman could be found."
-    echo >&2 "If you wish to use another container runtime, you can pass an executable to the `command` attribute."
+    echo >&2 "If you wish to use another container runtime, you can pass an executable to the 'command' attribute."
     exit 1
 fi
 

--- a/oci/private/tarball_run.sh.tpl
+++ b/oci/private/tarball_run.sh.tpl
@@ -2,7 +2,7 @@
 set -o pipefail -o errexit -o nounset
 
 readonly IMAGE="{{image_path}}"
-if [ -e "{{container_cli_tool}}" ]; then
+if [ -e "{{command}}" ]; then
     CONTAINER_CLI="{{container_cli_tool}}"
 elif command -v docker &> /dev/null; then
     CONTAINER_CLI="docker"

--- a/oci/private/tarball_run.sh.tpl
+++ b/oci/private/tarball_run.sh.tpl
@@ -10,7 +10,7 @@ elif command -v podman &> /dev/null; then
     CONTAINER_CLI="podman"
 else
     echo >&2 "Neither docker or podman could be found."
-    echo >&2 "If you wish to use another container runtime, you can pass command to oci_tarball(...)."
+    echo >&2 "If you wish to use another container runtime, you can pass an executable to the `command` attribute."
     exit 1
 fi
 

--- a/oci/private/tarball_run.sh.tpl
+++ b/oci/private/tarball_run.sh.tpl
@@ -3,14 +3,14 @@ set -o pipefail -o errexit -o nounset
 
 readonly IMAGE="{{image_path}}"
 if [ -e "{{command}}" ]; then
-    CONTAINER_CLI="{{container_cli_tool}}"
+    CONTAINER_CLI="{{command}}"
 elif command -v docker &> /dev/null; then
     CONTAINER_CLI="docker"
 elif command -v podman &> /dev/null; then
     CONTAINER_CLI="podman"
 else
     echo >&2 "Neither docker or podman could be found."
-    echo >&2 "If you wish to use another container runtime, you can pass container_cli_tool to oci_tarball(...)."
+    echo >&2 "If you wish to use another container runtime, you can pass command to oci_tarball(...)."
     exit 1
 fi
 

--- a/oci/private/tarball_run.sh.tpl
+++ b/oci/private/tarball_run.sh.tpl
@@ -2,13 +2,15 @@
 set -o pipefail -o errexit -o nounset
 
 readonly IMAGE="{{image_path}}"
-if command -v docker &> /dev/null; then
+if [ -e "{{container_cli_tool}}" ]; then
+    CONTAINER_CLI="{{container_cli_tool}}"
+elif command -v docker &> /dev/null; then
     CONTAINER_CLI="docker"
 elif command -v podman &> /dev/null; then
     CONTAINER_CLI="podman"
 else
     echo >&2 "Neither docker or podman could be found."
-    echo >&2 "If you wish to use another container runtime, please comment on https://github.com/bazel-contrib/rules_oci/issues/295."
+    echo >&2 "If you wish to use another container runtime, you can pass container_cli_tool to oci_tarball(...)."
     exit 1
 fi
 


### PR DESCRIPTION
Enables passing a label to `oci_tarball` which will be used to load the image into the local container engine.

Solves https://github.com/bazel-contrib/rules_oci/issues/295

Follows guidance from https://github.com/bazel-contrib/rules_oci/issues/430

I think it would be nice if `oci_register_toolchains` configured this, but I understand not wanting to clutter the configs.

To test:

WORKSPACE:
```
local_repository(
    name = "rules_oci",
    path = "/local/rules_oci",
)

load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

load("@rules_oci//oci:dependencies.bzl", "rules_oci_dependencies")

rules_oci_dependencies()

load("@rules_oci//oci:repositories.bzl", "LATEST_CRANE_VERSION", "oci_register_toolchains")

oci_register_toolchains(
    name = "oci",
    crane_version = LATEST_CRANE_VERSION,
)

load("@rules_oci//oci:pull.bzl", "oci_pull")

oci_pull(
    name = "distroless_base",
    digest = "sha256:ccaef5ee2f1850270d453fdf700a5392534f8d1a8ca2acda391fbb6a06b81c86",
    image = "gcr.io/distroless/base",
    platforms = [
        "linux/amd64",
        "linux/arm64",
    ],
)

# from https://download.docker.com/linux/static/stable/x86_64/
http_archive(
    name = "docker_cli",
    url = "https://download.docker.com/linux/static/stable/x86_64/docker-24.0.7.tgz",
    sha256 = "984d59a77fa6acab97ea725a966facd33725e0e09c2fee975397fe1c6379bd3d",
    build_file_content = """
exports_files(["docker/docker"])
    """
)
```

BUILD.bazel:
```
load("@rules_oci//oci:defs.bzl", "oci_image", "oci_tarball")

oci_image(
    name = "image",
    base = "@distroless_base",
    cmd = ["echo", "hi"],
)

oci_tarball(
    name = "tarball",
    image = ":image",
    repo_tags = ["jchorl/test:latest"],
    container_cli_tool = "@docker_cli//:docker/docker",
)
```

```
ubuntu@99ab9feb506a:/src/workspace$ bazel run //:tarball
INFO: Analyzed target //:tarball (1 packages loaded, 4 targets configured).
INFO: Found 1 target...
Target //:tarball up-to-date:
  bazel-bin/tarball/tarball.tar
INFO: Elapsed time: 0.046s, Critical Path: 0.00s
INFO: 4 processes: 4 internal.
INFO: Build completed successfully, 4 total actions
INFO: Running command line: bazel-bin/tarball.sh
Loaded image: jchorl/test:latest
```