### PR TITLE
fix: do not print message to stderr during normal operation

### DIFF
--- a/e2e/custom_registry/registry/launcher.sh
+++ b/e2e/custom_registry/registry/launcher.sh
@@ -34,7 +34,6 @@ function stop_registry() {
         echo "Registry not started" >&2
         return 0
     fi
-    echo "Stopping registry process" >&2
     kill -9 "$(cat "${registry_pid}")" || true
     return 0
 }

--- a/oci/private/registry/crane_launcher.sh.tpl
+++ b/oci/private/registry/crane_launcher.sh.tpl
@@ -37,7 +37,6 @@ function stop_registry() {
         echo "Registry not started" >&2
         return 0
     fi
-    echo "Stopping registry process" >&2
     kill -9 "$(cat "${registry_pid}")" || true
     return 0
 }

--- a/oci/private/registry/zot_launcher.sh.tpl
+++ b/oci/private/registry/zot_launcher.sh.tpl
@@ -42,7 +42,6 @@ function stop_registry() {
         echo "Registry not started" >&2
         return 0
     fi
-    echo "Stopping registry process" >&2
     kill -9 "$(cat "${registry_pid}")" || true
     return 0
 }


### PR DESCRIPTION
Follow-up for #421.
I noticed that those messages are always printed, even on success. Theoretically, there is a choice between printing those messages to stdout instead, silencing stderr on success or dropping the message.
The last option is the easiest.