### PR TITLE
chore: upgrade to Bazel 7

### DIFF
--- a/.bazelversion
+++ b/.bazelversion
@@ -1,4 +1,4 @@
-6.2.0
+7.0.0
 
 # The first line of this file is used by Bazelisk and Bazel to be sure
 # the right version of Bazel is used to build and test this repo.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,12 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - id: bazel_6
+      - id: bazel_7
         run: echo "bazelversion=$(head -n 1 .bazelversion)" >> $GITHUB_OUTPUT
-      - id: bazel_5
-        run: echo "bazelversion=5.3.2" >> $GITHUB_OUTPUT
+      - id: bazel_6
+        run: echo "bazelversion=6.4.0" >> $GITHUB_OUTPUT
     outputs:
-      # Will look like ["<version from .bazelversion>", "5.3.2"]
+      # Will look like ["<version from .bazelversion>", "6.4.0"]
       bazelversions: ${{ toJSON(steps.*.outputs.bazelversion) }}
 
   matrix-prep-os:
@@ -67,18 +67,15 @@ jobs:
         bzlmodEnabled: [true, false]
         exclude:
           # macos is expensive (billed at 10X) so don't test these
-          - os: macos-latest 
+          - os: macos-latest
             folder: e2e/custom_registry
-          - os: macos-latest 
+          - os: macos-latest
             folder: e2e/wasm
-          - os: macos-latest 
+          - os: macos-latest
             folder: e2e/crane_as_registry
           - os: macos-latest
-            bazelversion: 5.3.2
+            bazelversion: 6.4.0
 
-          # Don't test bzlmod with Bazel 5 (not supported)
-          - bazelversion: 5.3.2
-            bzlmodEnabled: true
           # TODO: fix
           - folder: e2e/custom_registry
             bzlmodEnabled: true
@@ -116,9 +113,9 @@ jobs:
         if: ${{ matrix.os == 'macos-latest' }}
         uses: atomicjar/testcontainers-cloud-setup-action@main
         with:
-            wait: true
-            token: ${{ secrets.TC_CLOUD_TOKEN }}
-      
+          wait: true
+          token: ${{ secrets.TC_CLOUD_TOKEN }}
+
       - name: Configure Remote Docker Host
         if: ${{ matrix.os == 'macos-latest' }}
         run: echo "DOCKER_HOST=$(grep 'tc.host' ~/.testcontainers.properties | cut -d '=' -f2 | xargs)" >> $GITHUB_ENV
@@ -129,7 +126,7 @@ jobs:
           # Bazelisk will download bazel to here, ensure it is cached between runs.
           XDG_CACHE_HOME: ~/.cache/bazel-repo
         run: bazel --bazelrc=$GITHUB_WORKSPACE/.github/workflows/ci.bazelrc --bazelrc=.bazelrc test ${{ steps.set_bzlmod_flag.outputs.bzlmod_flag }} //...
-  
+
   test-auth:
     runs-on: ubuntu-latest
     steps:

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,8 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "aspect_bazel_lib", version = "1.35.0")
+# Lower-bound dependency constraints. Don't bump these unless needed.
+bazel_dep(name = "aspect_bazel_lib", version = "1.36.0")
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "platforms", version = "0.0.5")
 

--- a/e2e/custom_registry/WORKSPACE
+++ b/e2e/custom_registry/WORKSPACE
@@ -53,10 +53,10 @@ container_structure_test_register_toolchain(name = "st")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "099a9fb96a376ccbbb7d291ed4ecbdfd42f6bc822ab77ae6f1b5cb9e914e94fa",
+    sha256 = "51dc53293afe317d2696d4d6433a4c33feedb7748a9e352072e2ec3c0dafd2c6",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.35.0/rules_go-v0.35.0.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.35.0/rules_go-v0.35.0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.40.1/rules_go-v0.40.1.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.40.1/rules_go-v0.40.1.zip",
     ],
 )
 

--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -4,7 +4,7 @@ bazel_dep(name = "container_structure_test", version = "1.15.0", dev_dependency 
 bazel_dep(name = "rules_oci", version = "0.0.0", dev_dependency = True)
 
 bazel_dep(name = "platforms", version = "0.0.5")
-bazel_dep(name = "aspect_bazel_lib", version = "1.32.0")
+bazel_dep(name = "aspect_bazel_lib", version = "1.36.0")
 bazel_dep(name = "bazel_skylib", version = "1.1.1")
 
 local_path_override(

--- a/oci/dependencies.bzl
+++ b/oci/dependencies.bzl
@@ -29,7 +29,7 @@ def rules_oci_dependencies():
 
     http_archive(
         name = "aspect_bazel_lib",
-        sha256 = "e9505bd956da64b576c433e4e41da76540fd8b889bbd17617fe480a646b1bfb9",
-        strip_prefix = "bazel-lib-1.35.0",
-        url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.35.0/bazel-lib-v1.35.0.tar.gz",
+        sha256 = "cbf473d630ab67b36461d83b38fdc44e56f45b78d03c405e4958280211124d79",
+        strip_prefix = "bazel-lib-1.36.0",
+        url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.36.0/bazel-lib-v1.36.0.tar.gz",
     )


### PR DESCRIPTION
Drops CI testing for Bazel 5, which we will soon stop supporting altogether. This is just to save CI resources, not because there's something broken with Bazel 5

Maybe repro #425