### PR TITLE
Remove uses of `incompatible_use_toolchain_transition`.

### DIFF
--- a/oci/private/toolchains_repo.bzl
+++ b/oci/private/toolchains_repo.bzl
@@ -90,7 +90,6 @@ def _resolved_toolchain_impl(ctx):
 resolved_toolchain = rule(
     implementation = _resolved_toolchain_impl,
     toolchains = ["{toolchain_type}"],
-    incompatible_use_toolchain_transition = True,
 )
 """
 


### PR DESCRIPTION
Now that Bazel 7.0 has been released, it's time to remove this tech debt.

This has been a no-op since Bazel 5.0, I've been waiting to remove the code for two years, it's time.

Part of https://github.com/bazelbuild/bazel/issues/14127.