### PR TITLE
chore: bump minimum bazel-lib

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,8 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "aspect_bazel_lib", version = "1.35.0")
+# Minimum 1.36.0 to include https://github.com/aspect-build/bazel-lib/pull/594
+bazel_dep(name = "aspect_bazel_lib", version = "1.36.0")
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "platforms", version = "0.0.5")
 

--- a/oci/dependencies.bzl
+++ b/oci/dependencies.bzl
@@ -29,7 +29,7 @@ def rules_oci_dependencies():
 
     http_archive(
         name = "aspect_bazel_lib",
-        sha256 = "e9505bd956da64b576c433e4e41da76540fd8b889bbd17617fe480a646b1bfb9",
-        strip_prefix = "bazel-lib-1.35.0",
-        url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.35.0/bazel-lib-v1.35.0.tar.gz",
+        sha256 = "4d6010ca5e3bb4d7045b071205afa8db06ec11eb24de3f023d74d77cca765f66",
+        strip_prefix = "bazel-lib-1.39.0",
+        url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.39.0/bazel-lib-v1.39.0.tar.gz",
     )

--- a/oci/private/pull.bzl
+++ b/oci/private/pull.bzl
@@ -26,7 +26,7 @@ _IMAGE_REFERENCE_ATTRS = {
     ),
     "config": attr.label(
         # TODO(2.0): remove
-        doc = "Label to a .docker/config.json file. `config` attribute overrides `config_path` attribute. DEPRECATED, will be removed in 2.0",
+        doc = "Label to a .docker/ file. `config` attribute overrides `config_path` attribute. DEPRECATED, will be removed in 2.0",
         allow_single_file = True,
     ),
     "config_path": attr.label(

--- a/oci/private/pull.bzl
+++ b/oci/private/pull.bzl
@@ -26,7 +26,7 @@ _IMAGE_REFERENCE_ATTRS = {
     ),
     "config": attr.label(
         # TODO(2.0): remove
-        doc = "Label to a .docker/ file. `config` attribute overrides `config_path` attribute. DEPRECATED, will be removed in 2.0",
+        doc = "Label to a .docker/config.json file. `config` attribute overrides `config_path` attribute. DEPRECATED, will be removed in 2.0",
         allow_single_file = True,
     ),
     "config_path": attr.label(


### PR DESCRIPTION
Require a newer aspect_bazel_lib, to pick up a fix for execution requirements - something about build-without-the-bytes causes the directory to be missing file contents.

Fixes #425