### PR TITLE
fix: glob blobs directory

### DIFF
--- a/oci/private/pull.bzl
+++ b/oci/private/pull.bzl
@@ -333,8 +333,7 @@ copy_to_directory(
     # Always use hardlink to avoid having copies of the blobs from external repository in the output-tree.
     hardlink = "on",
     include_external_repositories = ["*"],
-    srcs = [
-        "blobs",
+    srcs = glob(["blobs/**"]) + [
         "oci-layout",
         "index.json",
     ],


### PR DESCRIPTION
Bazel doesn't really support source directories and prints an annoying warning when one lists a source directory as dependency.

fixes #448