### PR TITLE
fix: missing error output on shell exit

### DIFF
--- a/oci/private/image.sh.tpl
+++ b/oci/private/image.sh.tpl
@@ -13,11 +13,11 @@ readonly STORAGE_DIR="{{storage_dir}}"
 readonly STDERR=$(mktemp)
 
 silent_on_success() {
-    stop_registry ${STORAGE_DIR}
     CODE=$?
     if [ "${CODE}" -ne 0 ]; then
         cat "${STDERR}" >&1
     fi
+    stop_registry ${STORAGE_DIR}
 }
 trap "silent_on_success" EXIT
 


### PR DESCRIPTION
If oci_image script failes, there is no error output anymore since #421, this simple fix tries to address that.

Since `stop_registry` is fairly simple enough, so I think we can ignore the exit code about it.