### PR TITLE
Added strip to the path read

### DIFF
--- a/oci/private/pull.bzl
+++ b/oci/private/pull.bzl
@@ -312,7 +312,7 @@ def _get_auth_config_path(rctx):
         path = rctx.read(rctx.path(rctx.attr.config_path))
 
     if path:
-        return json.decode(rctx.read(path))
+        return json.decode(rctx.read(path).strip())
 
     return {}
 

--- a/oci/private/pull.bzl
+++ b/oci/private/pull.bzl
@@ -312,7 +312,7 @@ def _get_auth_config_path(rctx):
         path = rctx.read(rctx.path(rctx.attr.config_path))
 
     if path:
-        return json.decode(rctx.read(path).strip())
+        return json.decode(rctx.read(path.strip()))
 
     return {}
 


### PR DESCRIPTION
Simple bug fix to strip the path in the read config file. We had an EOF fixer that was running on our codebase and when it encountered this path, it failed to parse it. This PR adds a simple fix to strip whitespace out of the path to deal with File Not Found exceptions 