### PR TITLE
Add quay.io registry support

### DIFF
--- a/fetch.bzl
+++ b/fetch.bzl
@@ -159,6 +159,14 @@ def fetch_images():
         platforms = ["linux/amd64"],
     )
 
+    oci_pull(
+        name = "quay_clair_image",
+        # tag = "4.7.2",
+        image = "quay.io/projectquay/clair",
+        digest = "sha256:8d38ffa8fad72f4bc2647644284c16491cc2d375602519a1f963f96ccc916276",
+        platforms = ["linux/amd64"],
+    )
+
     _DEB_TO_LAYER = """\
 alias(
     name = "layer",

--- a/oci/private/pull.bzl
+++ b/oci/private/pull.bzl
@@ -79,6 +79,11 @@ _WWW_AUTH = {
         "scope": "repository:{repository}:pull",
         "service": "token-service",
     },
+    "quay.io": {
+        "realm": "{registry}/v2/auth",
+        "scope": "repository:{repository}:pull",
+        "service": "{registry}",
+    },
 }
 
 def _strip_host(url):

--- a/oci/tests/BUILD.bazel
+++ b/oci/tests/BUILD.bazel
@@ -65,6 +65,7 @@ build_test(
         "@from_rules_docker",
         "@ubuntu",
         "@es_kibana_image",
+        "@quay_clair_image",
     ],
 )
 


### PR DESCRIPTION
Allows oci_pull from private quay.io repositories.

Follows https://github.com/bazel-contrib/rules_oci/pull/471