### PR TITLE
chore: repository cleanup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.ref }}
+  # Cancel previous actions from the same PR: https://stackoverflow.com/a/72408109
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -20,7 +21,7 @@ jobs:
     # Prepares the 'bazelversion' axis of the test matrix
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - id: bazel_6
         run: echo "bazelversion=$(head -n 1 .bazelversion)" >> $GITHUB_OUTPUT
       - id: bazel_5
@@ -93,7 +94,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Mount bazel caches
         uses: actions/cache@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release:
-    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@2ded56de883b35b1e18b37566fd406625153f1e2
+    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v5
     with:
       release_files: rules_oci-*.tar.gz
       prerelease: false

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -7,8 +7,8 @@ statement from these, that's a bug in our distribution.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", _http_archive = "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
-def http_archive(name, **kwargs):
-    maybe(_http_archive, name = name, **kwargs)
+def http_archive(**kwargs):
+    maybe(_http_archive, **kwargs)
 
 def rules_oci_internal_deps():
     "Fetch deps needed for local development"

--- a/oci/dependencies.bzl
+++ b/oci/dependencies.bzl
@@ -7,17 +7,10 @@ See https://docs.bazel.build/versions/main/skylark/deploying.html#dependencies
 load("@bazel_tools//tools/build_defs/repo:http.bzl", _http_archive = "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
-def http_archive(name, **kwargs):
-    maybe(_http_archive, name = name, **kwargs)
+def http_archive(**kwargs):
+    maybe(_http_archive, **kwargs)
 
-# WARNING: any changes in this function may be BREAKING CHANGES for users
-# because we'll fetch a dependency which may be different from one that
-# they were previously fetching later in their WORKSPACE setup, and now
-# ours took precedence. Such breakages are challenging for users, so any
-# changes in this function should be marked as BREAKING in the commit message
-# and released only in semver majors.
 def rules_oci_dependencies():
-    # The minimal version of bazel_skylib we require
     http_archive(
         name = "bazel_skylib",
         sha256 = "c6966ec828da198c5d9adbaa94c05e3a1c7f21bd012a0b29ba8ddbccb2c93b0d",


### PR DESCRIPTION
Just some minor cleanup make this repository consistent with all our other OSS repos.
- maybe pattern doesn't use name elsewehre
- update to actions/checkout@v4
- use correct pattern for GHA PR concurrency
- update to bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v5
- remove the big WARNING from rules_oci_dependencies; this doesn't exist in our other repos anymore