### PR TITLE
fix: blob directory is wrong

### DIFF
--- a/oci/private/registry/crane_launcher.sh.tpl
+++ b/oci/private/registry/crane_launcher.sh.tpl
@@ -7,8 +7,8 @@ function start_registry() {
     local deadline="${3:-5}"
     local registry_pid="$1/proc.pid"
 
-    mkdir -p "${storage_dir}"
-    "${CRANE_REGISTRY_BIN}" registry serve --disk="${storage_dir}" --address=localhost:0 >> $output 2>&1 &
+    mkdir -p "${storage_dir}/blobs"
+    "${CRANE_REGISTRY_BIN}" registry serve --disk="${storage_dir}/blobs" --address=localhost:0 >> $output 2>&1 &
     echo "$!" > "${registry_pid}"
     
     local timeout=$((SECONDS+${deadline}))


### PR DESCRIPTION
https://github.com/google/go-containerregistry/pull/1810 introduced this feature where blobs are written to `disk_path/hex/digest` but rules_oci assumed that it was `disk_path/blobs/hex/digest` so blobs were written to the wrong place..