### PR TITLE
Revert "fix: improve error reporting"

### DIFF
--- a/oci/private/image.sh.tpl
+++ b/oci/private/image.sh.tpl
@@ -62,9 +62,7 @@ function base_from_layout() {
 
     "${CRANE}" push "${oci_layout_path}" "${registry}/image:latest" --image-refs "${refs}" > "${output}" 2>&1
 
-
-    if [[ $? != 0 ]]; then 
-      if grep -q "MANIFEST_INVALID" "${output}"; then
+    if grep -q "MANIFEST_INVALID" "${output}"; then
     cat >&2 << EOF
 
 zot registry does not support docker manifests. 
@@ -74,11 +72,10 @@ crane registry does support both oci and docker images, but is more memory hungr
 If you want to use the crane registry, remove "zot_version" from "oci_register_toolchains". 
 
 EOF
-      else
-        cat "${output}"
-      fi
-      exit 1
+
+        exit 1
     fi
+
     cat "${refs}"
 }
 


### PR DESCRIPTION
Reverts bazel-contrib/rules_oci#490

In some client testing, this breaks the build. I think `crane push` actually does exit non-zero in the happy path case.