### PR TITLE
feat: add nvcr.io to _WWW_AUTH

### DIFF
--- a/fetch.bzl
+++ b/fetch.bzl
@@ -187,6 +187,13 @@ def fetch_images():
         ],
     )
 
+    oci_pull(
+        name = "nvidia_k8s_device_plugin_image",
+        # tag = "v0.14.4",
+        digest = "sha256:19c696958fe8a63676ba26fa57114c33149168bbedfea246fc55e0e665c03098",
+        image = "nvcr.io/nvidia/k8s-device-plugin",
+    )
+
     _DEB_TO_LAYER = """\
 alias(
     name = "layer",

--- a/oci/private/authn.bzl
+++ b/oci/private/authn.bzl
@@ -48,6 +48,11 @@ _WWW_AUTH = {
         "scope": "repository:{repository}:pull",
         "service": "token-service",
     },
+    "nvcr.io": {
+        "realm": "{registry}/proxy_auth",
+        "scope": "repository:{repository}:pull",
+        "service": "{registry}",
+    },
 }
 
 def _strip_host(url):

--- a/oci/tests/BUILD.bazel
+++ b/oci/tests/BUILD.bazel
@@ -67,6 +67,7 @@ build_test(
         "@ubuntu",
         "@es_kibana_image",
         "@quay_clair_image",
+        "@nvidia_k8s_device_plugin_image",
     ],
 )
 


### PR DESCRIPTION
I reported the issue at https://github.com/bazel-contrib/rules_oci/issues/475#issuecomment-1960581407 that `oci_pull` fails to download images from nvcr.io. As suggested in the comment at https://github.com/bazel-contrib/rules_oci/issues/284#issuecomment-1692815824, I added a new entry for nvcr.io to `_WWW_AUTH`. I locally applied the patch and confirmed that `oci_pull` successfully downloaded images which were previously failed.

I took the values from the information provided at https://forums.developer.nvidia.com/t/how-to-get-manifest-from-nvcr-io-docker-registry-using-rest-api/72385/2