### PR TITLE
fix: fix util.sha256 error code handling

### DIFF
--- a/oci/private/util.bzl
+++ b/oci/private/util.bzl
@@ -61,9 +61,9 @@ def _sha256(rctx, path):
     # on MacOS, but is not necessarily always available on Linux. OpenSSL is used as a final
     # fallback if neither are available
     result = rctx.execute(["shasum", "-a", "256", path])
-    if result.return_code == 127:  # 127 return code indicates command not found
+    if result.return_code:
         result = rctx.execute(["sha256sum", path])
-    if result.return_code == 127:
+    if result.return_code:
         result = rctx.execute(["openssl", "sha256", "-r", path])
     if result.return_code:
         msg = "sha256 failed: \nSTDOUT:\n%s\nSTDERR:\n%s" % (result.stdout, result.stderr)


### PR DESCRIPTION
rctx.execute will not return 127 if shasum is not found on a linux machine; you'll just get an error code of 1 when that happens