### PR TITLE
Revert "feat: use link instead of copy for blobs in oci_image_index"

### DIFF
--- a/oci/private/image_index.sh.tpl
+++ b/oci/private/image_index.sh.tpl
@@ -35,7 +35,7 @@ function copy_blob() {
     local blob_image_relative_path="$3"
     local dest_path="${output_path}/${blob_image_relative_path}"
     mkdirp "$(dirname "${dest_path}")"
-    "${COREUTILS}" ln -f "${image_path}/${blob_image_relative_path}" "${dest_path}"
+    "${COREUTILS}" cat "${image_path}/${blob_image_relative_path}" > "${dest_path}"
 }
 
 function create_oci_layout() {


### PR DESCRIPTION
Reverts bazel-contrib/rules_oci#359

Context: users started seeing cryptic errors which i believe started with this commit. Will confirm that it's the case.

I have no idea why i merged this but up until 7.1 bazel did not support symlinks inside treeartifacts pointing out of it.