### PR TITLE
Support inheriting environment variable that's value contains =

### DIFF
--- a/examples/env_inheritance/BUILD.bazel
+++ b/examples/env_inheritance/BUILD.bazel
@@ -9,14 +9,23 @@ pkg_tar(
 )
 
 oci_image(
-    name = "image",
+    name = "middle_image",
     base = "@ubuntu",
     cmd = ["test.sh"],
     env = {
         "ENV1": "$PATH:/test",
         "ENV2": "/prepend:${PATH}:/test2",
+        "ENV3": "key1=value1 key2=value2",
     },
     tars = ["app.tar"],
+)
+
+oci_image(
+    name = "image",
+    base = ":middle_image",
+    env = {
+        "ENV4": "${ENV3} key3=value3",
+    },
 )
 
 container_structure_test(

--- a/examples/env_inheritance/test.yaml
+++ b/examples/env_inheritance/test.yaml
@@ -14,3 +14,7 @@ metadataTest:
       value: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/test"
     - key: "ENV2"
       value: "/prepend:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/test2"
+    - key: "ENV3"
+      value: "key1=value1 key2=value2"
+    - key: "ENV4"
+      value: "key1=value1 key2=value2 key3=value3"

--- a/oci/private/image.sh
+++ b/oci/private/image.sh
@@ -124,7 +124,7 @@ REF=$("${CRANE}" "${FIXED_ARGS[@]}")
 
 # Expand environment variables
 if [ ${#ENV_EXPANSIONS[@]} -ne 0 ]; then 
-    base_env=$( "${CRANE}" config "${REF}" | "${JQ}" -r '.config.Env | map(. | split("=") | {"key": .[0], "value": .[1]}) | from_entries')
+    base_env=$( "${CRANE}" config "${REF}" | "${JQ}" -r '.config.Env | map(. | split("=") | {"key": .[0], "value": .[1:] | join("=")}) | from_entries')
     environment_args=()
     for expansion in "${ENV_EXPANSIONS[@]}"
     do


### PR DESCRIPTION
If base image contained a variable  `BASE_VAR=key=value` and one would set `MY_VAR=$BASE_VAR additional value` the `MY_VAR` would be set to `key additional value`

Fixing this by parsing `config.Env` elements as:
1. variable name - string up to first "="
2. variable value - whole string after first "="