### PR TITLE
Pass headers to Bazel downloader where available

### DIFF
--- a/oci/BUILD.bazel
+++ b/oci/BUILD.bazel
@@ -69,6 +69,16 @@ bzl_library(
 )
 
 bzl_library(
+    name = "extensions",
+    srcs = ["extensions.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":pull",
+        ":repositories",
+    ],
+)
+
+bzl_library(
     name = "toolchain",
     srcs = ["toolchain.bzl"],
     visibility = ["//visibility:public"],

--- a/oci/private/download.bzl
+++ b/oci/private/download.bzl
@@ -118,7 +118,11 @@ def _bazel_download(
         headers = {},
         # passthrough
         **kwargs):
-    return rctx.download(**kwargs)
+    # Passing headers to the downloader is only available as of 7.1
+    if versions.is_at_least("7.1.0", versions.get() or "7.1.0"):
+        return rctx.download(headers = headers, **kwargs)
+    else:
+        return rctx.download(**kwargs)
 
 download = struct(
     curl = _download,

--- a/oci/private/download.bzl
+++ b/oci/private/download.bzl
@@ -109,17 +109,12 @@ def _download(
     )
 
 # A dummy function that uses bazel downloader.
-#  Caveats
-#   - Doesn't support setting custom headers
 def _bazel_download(
         rctx,
-        # custom features
-        # buildifier: disable=unused-variable
         headers = {},
-        # passthrough
         **kwargs):
     # Passing headers to the downloader is only available as of 7.1
-    if versions.is_at_least("7.1.0", versions.get() or "7.1.0"):
+    if versions.is_at_least("7.1.0", versions.get()):
         return rctx.download(headers = headers, **kwargs)
     else:
         return rctx.download(**kwargs)

--- a/oci/private/pull.bzl
+++ b/oci/private/pull.bzl
@@ -63,6 +63,11 @@ _SUPPORTED_MEDIA_TYPES = {
     ],
 }
 
+_DOWNLOAD_HEADERS = {
+    "Accept": ",".join(_SUPPORTED_MEDIA_TYPES["index"] + _SUPPORTED_MEDIA_TYPES["manifest"]),
+    "Docker-Distribution-API-Version": "registry/2.0",
+}
+
 def _config_path(rctx):
     if rctx.attr.config:
         return rctx.path(rctx.attr.config)
@@ -120,7 +125,15 @@ def _download_manifest(rctx, authn, identifier, output):
     manifest = None
     digest = None
 
-    result = _download(rctx, authn, identifier, output, "manifests", allow_fail = True)
+    result = _download(
+        rctx,
+        authn,
+        identifier,
+        output,
+        "manifests",
+        allow_fail = True,
+        headers = _DOWNLOAD_HEADERS,
+    )
 
     fallback_to_curl = False
     if result.success:
@@ -146,10 +159,7 @@ def _download_manifest(rctx, authn, identifier, output):
             output,
             "manifests",
             download.curl,
-            headers = {
-                "Accept": ",".join(_SUPPORTED_MEDIA_TYPES["index"] + _SUPPORTED_MEDIA_TYPES["manifest"]),
-                "Docker-Distribution-API-Version": "registry/2.0",
-            },
+            headers = _DOWNLOAD_HEADERS,
         )
         bytes = rctx.read(output)
         manifest = json.decode(bytes)


### PR DESCRIPTION
As of Bazel 7.1, it is possible to pass arbitrary headers to the Bazel downloader. Combined with proper credentials, this change makes it possible to avoid the cURL fallback on 7.1+.

It feels weird to pass the same headers to every invocation of `_download()`. Should we move `_SUPPORTED_MEDIA_TYPES` and `_DOWNLOAD_HEADERS` somewhere they could be imported in `download.bzl`?