### PR TITLE
Use platform transition in the oci_image_index rule

### DIFF
--- a/docs/image_index.md
+++ b/docs/image_index.md
@@ -7,7 +7,7 @@ Implementation details for oci_image_index rule
 ## oci_image_index
 
 <pre>
-oci_image_index(<a href="#oci_image_index-name">name</a>, <a href="#oci_image_index-images">images</a>)
+oci_image_index(<a href="#oci_image_index-name">name</a>, <a href="#oci_image_index-image">image</a>, <a href="#oci_image_index-images">images</a>, <a href="#oci_image_index-platforms">platforms</a>)
 </pre>
 
 Build a multi-architecture OCI compatible container image.
@@ -18,19 +18,65 @@ Requires `wc` and either `sha256sum` or `shasum` to be installed on the executio
 
 ```starlark
 oci_image(
-    name = "app_linux_amd64"
-)
-
-oci_image(
-    name = "app_linux_arm64"
+    name = "app_linux"
 )
 
 oci_image_index(
     name = "app",
-    images = [
+    image = ":app_linux",
+    platforms = [
+        "@io_bazel_rules_go//go/toolchain:linux_amd64",
+        "@io_bazel_rules_go//go/toolchain:linux_arm64",
+    ]
+)
+```
+
+Deprecated use without platform transition:
+
+```starlark
+oci_image(
+    name = "app_linux_amd64",
+)
+
+oci_image(
+    name = "app_linux_arm64",
+)
+
+oci_image_index(
+    name = "app",
+    image = [
         ":app_linux_amd64",
         ":app_linux_arm64"
-    ]
+    ],
+)
+```
+
+Another variant for transitioning away from the deprecated use:
+
+```starlark
+oci_image(
+    name = "app_linux_amd64",
+)
+
+oci_image(
+    name = "app_linux_arm64",
+)
+
+alias(
+    name = "app_linux",
+    actual = select({
+        "@platforms//cpu:x86_64": ":app_linux_amd64",
+        "@platforms//cpu:aarch64": ":app_linux_arm64",
+    }),
+)
+
+oci_image_index(
+    name = "app",
+    image = ":app_linux",
+    platforms = [
+        "@io_bazel_rules_go//go/toolchain:linux_amd64",
+        "@io_bazel_rules_go//go/toolchain:linux_arm64",
+    ],
 )
 ```
 
@@ -41,6 +87,8 @@ oci_image_index(
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="oci_image_index-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="oci_image_index-images"></a>images |  List of labels to oci_image targets.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
+| <a id="oci_image_index-image"></a>image |  An oci_image target.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
+| <a id="oci_image_index-images"></a>images |  (Deprecated) List of labels to oci_image targets.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
+| <a id="oci_image_index-platforms"></a>platforms |  The platforms to build the index for. Defaults to <code>[]</code> which means that only the current target platform is used.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 
 

--- a/docs/push.md
+++ b/docs/push.md
@@ -76,19 +76,16 @@ oci_push(
 Push a multi-architecture image to github container registry with a semver tag
 
 ```starlark
-oci_image(name = "app_linux_arm64")
-
-oci_image(name = "app_linux_amd64")
-
-oci_image(name = "app_windows_amd64")
+oci_image(name = "app_image")
 
 oci_image_index(
-    name = "app_image",
-    images = [
-        ":app_linux_arm64",
-        ":app_linux_amd64",
-        ":app_windows_amd64",
-    ]
+    name = "app_index",
+    image = ":app_image",
+    platforms = [
+        "@my_platforms//:linux_arm64",
+        "@my_platforms//:linux_amd64",
+        "@my_platforms//:windows_amd64",
+    ],
 )
 
 write_file(
@@ -110,7 +107,7 @@ expand_template(
 )
 
 oci_push(
-    image = ":app_image",
+    image = ":app_index",
     repository = "ghcr.io/&lt;OWNER&gt;/image",
     remote_tags = ":stamped",
 )

--- a/oci/private/image_index.bzl
+++ b/oci/private/image_index.bzl
@@ -8,25 +8,94 @@ Requires `wc` and either `sha256sum` or `shasum` to be installed on the executio
 
 ```starlark
 oci_image(
-    name = "app_linux_amd64"
-)
-
-oci_image(
-    name = "app_linux_arm64"
+    name = "app_linux"
 )
 
 oci_image_index(
     name = "app",
-    images = [
+    image = ":app_linux",
+    platforms = [
+        "@io_bazel_rules_go//go/toolchain:linux_amd64",
+        "@io_bazel_rules_go//go/toolchain:linux_arm64",
+    ]
+)
+```
+
+Deprecated use without platform transition:
+
+```starlark
+oci_image(
+    name = "app_linux_amd64",
+)
+
+oci_image(
+    name = "app_linux_arm64",
+)
+
+oci_image_index(
+    name = "app",
+    image = [
         ":app_linux_amd64",
         ":app_linux_arm64"
-    ]
+    ],
+)
+```
+
+Another variant for transitioning away from the deprecated use:
+
+```starlark
+oci_image(
+    name = "app_linux_amd64",
+)
+
+oci_image(
+    name = "app_linux_arm64",
+)
+
+alias(
+    name = "app_linux",
+    actual = select({
+        "@platforms//cpu:x86_64": ":app_linux_amd64",
+        "@platforms//cpu:aarch64": ":app_linux_arm64",
+    }),
+)
+
+oci_image_index(
+    name = "app",
+    image = ":app_linux",
+    platforms = [
+        "@io_bazel_rules_go//go/toolchain:linux_amd64",
+        "@io_bazel_rules_go//go/toolchain:linux_arm64",
+    ],
 )
 ```
 """
 
+def _oci_platform_transition_impl(settings, attr):
+    if attr.platforms == []:
+        # No platform specified, use the current target platform only.
+        ret = [settings]
+    else:
+        ret = [
+            {
+                "//command_line_option:platforms": [platform],
+            }
+            for platform in attr.platforms
+        ]
+    return ret
+
+_oci_platform_transition = transition(
+    implementation = _oci_platform_transition_impl,
+    inputs = ["//command_line_option:platforms"],
+    outputs = ["//command_line_option:platforms"],
+)
+
 _attrs = {
-    "images": attr.label_list(mandatory = True, doc = "List of labels to oci_image targets."),
+    "images": attr.label_list(mandatory = False, doc = "List of labels to oci_image targets."),
+    "image": attr.label(mandatory = False, doc = "An oci_image target.", cfg = _oci_platform_transition),
+    "platforms": attr.label_list(mandatory = False, default = [], doc = """
+        The platforms to build the index for. Defaults to `[]` which means that only the current target platform is used.
+    """),
     "_image_index_sh_tpl": attr.label(default = "image_index.sh.tpl", allow_single_file = True),
 }
 
@@ -56,12 +125,23 @@ def _oci_image_index_impl(ctx):
 
     output = ctx.actions.declare_directory(ctx.label.name)
 
+    if ctx.attr.images:
+        if ctx.attr.image or ctx.attr.platforms:
+            fail("Specify either 'images' OR 'image' and 'platforms'.")
+        print("Deprecated use of 'images' in %s. Please change to 'image' and 'platforms'." % ctx.label)
+        image_files = ctx.files.images
+    else:
+        image_files = depset(transitive = [
+            image[DefaultInfo].files
+            for image in ctx.attr.image
+        ])
+
     args = ctx.actions.args()
     args.add(output.path, format = "--output=%s")
-    args.add_all(ctx.files.images, map_each = _expand_image_to_args, expand_directories = False)
+    args.add_all(image_files, map_each = _expand_image_to_args, expand_directories = False)
 
     ctx.actions.run(
-        inputs = ctx.files.images,
+        inputs = image_files,
         arguments = [args],
         outputs = [output],
         executable = launcher,

--- a/oci/private/image_index.bzl
+++ b/oci/private/image_index.bzl
@@ -91,7 +91,7 @@ _oci_platform_transition = transition(
 )
 
 _attrs = {
-    "images": attr.label_list(mandatory = False, doc = "List of labels to oci_image targets."),
+    "images": attr.label_list(mandatory = False, doc = "(Deprecated) List of labels to oci_image targets."),
     "image": attr.label(mandatory = False, doc = "An oci_image target.", cfg = _oci_platform_transition),
     "platforms": attr.label_list(mandatory = False, default = [], doc = """
         The platforms to build the index for. Defaults to `[]` which means that only the current target platform is used.

--- a/oci/private/image_index.bzl
+++ b/oci/private/image_index.bzl
@@ -97,6 +97,7 @@ _attrs = {
         The platforms to build the index for. Defaults to `[]` which means that only the current target platform is used.
     """),
     "_image_index_sh_tpl": attr.label(default = "image_index.sh.tpl", allow_single_file = True),
+    "_allowlist_function_transition": attr.label(default = "@bazel_tools//tools/allowlists/function_transition_allowlist"),
 }
 
 def _expand_image_to_args(image, expander):

--- a/oci/private/push.bzl
+++ b/oci/private/push.bzl
@@ -62,19 +62,16 @@ oci_push(
 Push a multi-architecture image to github container registry with a semver tag
 
 ```starlark
-oci_image(name = "app_linux_arm64")
-
-oci_image(name = "app_linux_amd64")
-
-oci_image(name = "app_windows_amd64")
+oci_image(name = "app_image")
 
 oci_image_index(
-    name = "app_image",
-    images = [
-        ":app_linux_arm64",
-        ":app_linux_amd64",
-        ":app_windows_amd64",
-    ]
+    name = "app_index",
+    image = ":app_image",
+    platforms = [
+        "@my_platforms//:linux_arm64",
+        "@my_platforms//:linux_amd64",
+        "@my_platforms//:windows_amd64",
+    ],
 )
 
 write_file(
@@ -96,7 +93,7 @@ expand_template(
 )
 
 oci_push(
-    image = ":app_image",
+    image = ":app_index",
     repository = "ghcr.io/<OWNER>/image",
     remote_tags = ":stamped",
 )


### PR DESCRIPTION
The current way of listing images makes Bazel build images for a platform that is not the configured target platform, defined by --platforms. This commit changes the behaviour and applies a transition so that the images are built for the configured target platform.

New way:
```
oci_image_index(
    name = "app",
    image = ":app_linux",
    platforms = [
        "@io_bazel_rules_go//go/toolchain:linux_amd64",
        "@io_bazel_rules_go//go/toolchain:linux_arm64",
    ]
)
```

Old way:
```
oci_image_index(
    name = "app",
    image = [
        ":app_linux_amd64",
        ":app_linux_arm64"
    ],
)
```

For backwards compatibility, the old way is still possible to use.