### PR TITLE
Add cosign v2.2.3

### DIFF
--- a/cosign/private/versions.bzl
+++ b/cosign/private/versions.bzl
@@ -9,7 +9,7 @@ COSIGN_VERSIONS = {
         "linux-arm64": "sha256-sIjWdvDAEjuMNI4Y1CHPlmAg7cSXekhhFaEmQ96pmj8=",
         "linux-ppc64le": "sha256-IaAWkdvfyzUbTpTM9QGk6HNyLPX+b2epc172bstBlB0=",
         "linux-s390x": "sha256-1yzyiRkNKMacuVxeMhOaoZgf/KCoQyfImgErsfOoBR0=",
-    }
+    },
     "v2.0.2": {
         "darwin-amd64": "sha256-D1HL4ZoxW5GehwQvBIUzGCFyLst/ziLMG4gO1IM/yLA=",
         "darwin-arm64": "sha256-VSQqUuvKQ9+xM9D+JuEVRr+kVxrd1oUteCwRnXTereE=",

--- a/cosign/private/versions.bzl
+++ b/cosign/private/versions.bzl
@@ -1,6 +1,15 @@
 "Mirrored versions/integrity hashes of cosign binaries"
 
 COSIGN_VERSIONS = {
+    "v2.2.3": {
+        "darwin-amd64": "sha256-JCn0sCf8MRpjJOnbb7OpN9VZ3GHekGocLQ0eBnFoXkw=",
+        "darwin-arm64": "sha256-PZWrRtTEzFXmRldYwjjcA/gwzIofw4vHozvCA+D7LDs=",
+        "linux-amd64": "sha256-9mn0EXbLHVi7aj/bBuJIYVQM/bWlcbTsXrIhiw310wQ=",
+        "linux-arm": "sha256-ywrOSvXPIoncxhZZF08tW9CzGpOOu9O2S2UKT9njRr8=",
+        "linux-arm64": "sha256-sIjWdvDAEjuMNI4Y1CHPlmAg7cSXekhhFaEmQ96pmj8=",
+        "linux-ppc64le": "sha256-IaAWkdvfyzUbTpTM9QGk6HNyLPX+b2epc172bstBlB0=",
+        "linux-s390x": "sha256-1yzyiRkNKMacuVxeMhOaoZgf/KCoQyfImgErsfOoBR0=",
+    }
     "v2.0.2": {
         "darwin-amd64": "sha256-D1HL4ZoxW5GehwQvBIUzGCFyLst/ziLMG4gO1IM/yLA=",
         "darwin-arm64": "sha256-VSQqUuvKQ9+xM9D+JuEVRr+kVxrd1oUteCwRnXTereE=",


### PR DESCRIPTION
fixes #535 

In addition I think older releases of cosign that depend on the TUF repository should be removed cc: @haydentherapper