### PR TITLE
feat: universal www-authenticate support

### DIFF
--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -13,7 +13,7 @@ new_local_repository(
 # Fetching various images
 load(":fetch.bzl", "fetch_images")
 
-fetch_images()
+fetch_images(is_bzlmod = True)
 
 ### Setup rules_oci cosign
 load("//cosign:repositories.bzl", "cosign_register_toolchains")

--- a/docs/pull.md
+++ b/docs/pull.md
@@ -94,7 +94,7 @@ See the [examples/credential_helper](/examples/credential_helper/auth.sh) direct
 
 <pre>
 oci_pull(<a href="#oci_pull-name">name</a>, <a href="#oci_pull-image">image</a>, <a href="#oci_pull-repository">repository</a>, <a href="#oci_pull-registry">registry</a>, <a href="#oci_pull-platforms">platforms</a>, <a href="#oci_pull-digest">digest</a>, <a href="#oci_pull-tag">tag</a>, <a href="#oci_pull-reproducible">reproducible</a>, <a href="#oci_pull-is_bzlmod">is_bzlmod</a>, <a href="#oci_pull-config">config</a>,
-         <a href="#oci_pull-config_path">config_path</a>)
+         <a href="#oci_pull-config_path">config_path</a>, <a href="#oci_pull-www_authenticate">www_authenticate</a>)
 </pre>
 
 Repository macro to fetch image manifest data from a remote docker registry.
@@ -123,5 +123,6 @@ in rules like `oci_image`.
 | <a id="oci_pull-is_bzlmod"></a>is_bzlmod |  whether the oci_pull is being called from a module extension   |  <code>False</code> |
 | <a id="oci_pull-config"></a>config |  Label to a <code>.docker/config.json</code> file.   |  <code>None</code> |
 | <a id="oci_pull-config_path"></a>config_path |  Deprecated. use <code>config</code> attribute or DOCKER_CONFIG environment variable.   |  <code>None</code> |
+| <a id="oci_pull-www_authenticate"></a>www_authenticate |  <p align="center"> - </p>   |  <code>False</code> |
 
 

--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -21,5 +21,6 @@ oci.pull(
         "linux/amd64",
         "linux/arm64",
     ],
+    www_authenticate = True,
 )
 use_repo(oci, "distroless_base")

--- a/fetch.bzl
+++ b/fetch.bzl
@@ -7,11 +7,12 @@ by writing them to a generated macro in a .bzl file.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@rules_oci//oci:pull.bzl", "oci_pull")
 
-def fetch_images():
+def fetch_images(is_bzlmod = False):
     "Fetch external images"
 
     # A single-arch base image
     oci_pull(
+        is_bzlmod = is_bzlmod,
         name = "distroless_java",
         digest = "sha256:161a1d97d592b3f1919801578c3a47c8e932071168a96267698f4b669c24c76d",
         image = "gcr.io/distroless/java17",
@@ -19,6 +20,7 @@ def fetch_images():
 
     # A multi-arch base image
     oci_pull(
+        is_bzlmod = is_bzlmod,
         name = "distroless_static",
         digest = "sha256:c3c3d0230d487c0ad3a0d87ad03ee02ea2ff0b3dcce91ca06a1019e07de05f12",
         image = "gcr.io/distroless/static",
@@ -31,18 +33,19 @@ def fetch_images():
         ],
     )
 
-    # Pull an image from public ECR. 
+    # Pull an image from public ECR.
     # When --credential_helper is provided, see .bazelrc at workspace root, it will take precende over
-    # auth from oci_pull. However, pulling from public ECR works out of the box so this will never fail 
+    # auth from oci_pull. However, pulling from public ECR works out of the box so this will never fail
     # unless oci_pull's authentication mechanism breaks and --credential_helper is absent.
     oci_pull(
+        is_bzlmod = is_bzlmod,
         name = "ecr_lambda_python",
         image = "public.ecr.aws/lambda/python",
         tag = "3.11.2024.01.25.10",
         platforms = [
             "linux/amd64",
-            "linux/arm64/v8"
-        ]
+            "linux/arm64/v8",
+        ],
     )
 
     # Show that the digest is optional.
@@ -51,6 +54,7 @@ def fetch_images():
     # reproducible = False.
     # This is more convenient, so you might decide the trade-off is worth it.
     oci_pull(
+        is_bzlmod = is_bzlmod,
         name = "distroless_python",
         image = "gcr.io/distroless/python3",
         platforms = ["linux/amd64"],
@@ -61,6 +65,7 @@ def fetch_images():
 
     # You can copy-paste a typical image string from dockerhub search results.
     oci_pull(
+        is_bzlmod = is_bzlmod,
         name = "debian_latest",
         image = "debian:latest",
         reproducible = False,
@@ -70,6 +75,7 @@ def fetch_images():
     # You can use a digest on the image name
     # https://hub.docker.com/layers/library/debian/stable/images/sha256-e822570981e13a6ef1efcf31870726fbd62e72d9abfdcf405a9d8f566e8d7028?context=explore
     oci_pull(
+        is_bzlmod = is_bzlmod,
         name = "debian_stable",
         image = "debian@sha256:e822570981e13a6ef1efcf31870726fbd62e72d9abfdcf405a9d8f566e8d7028",
     )
@@ -83,6 +89,7 @@ def fetch_images():
     #     digest = "sha256:deadbeef",
     # )
     oci_pull(
+        is_bzlmod = is_bzlmod,
         name = "from_rules_docker",
         registry = "gcr.io",
         repository = "distroless/nodejs18",
@@ -91,6 +98,7 @@ def fetch_images():
     )
 
     oci_pull(
+        is_bzlmod = is_bzlmod,
         name = "aws_lambda_python",
         # tag = "3.8"
         digest = "sha256:46b3b8614b31761b24f56be1bb8c7ba191d9b9b4624bbf7f53ed7ddc696c928b",
@@ -98,6 +106,7 @@ def fetch_images():
     )
 
     oci_pull(
+        is_bzlmod = is_bzlmod,
         name = "debian",
         # Omits the "image." CNAME for dockerhub
         image = "docker.io/library/debian",
@@ -118,6 +127,7 @@ def fetch_images():
     )
 
     oci_pull(
+        is_bzlmod = is_bzlmod,
         name = "ubuntu",
         image = "ubuntu",
         platforms = [
@@ -128,6 +138,7 @@ def fetch_images():
     )
 
     oci_pull(
+        is_bzlmod = is_bzlmod,
         name = "apollo_router",
         # tag = "v1.14.0",
         digest = "sha256:237c4d6a477b5013bae88549bfc50aaafd68974cab7d2dde2ba5431345e9c95d",
@@ -139,11 +150,13 @@ def fetch_images():
     )
 
     oci_pull(
+        is_bzlmod = is_bzlmod,
         name = "fluxcd_flux",
         image = "docker.io/fluxcd/flux:1.25.4",
     )
 
     oci_pull(
+        is_bzlmod = is_bzlmod,
         name = "chainguard_static",
         image = "cgr.dev/chainguard/static",
         platforms = [
@@ -159,6 +172,7 @@ def fetch_images():
     )
 
     oci_pull(
+        is_bzlmod = is_bzlmod,
         name = "gitlab_assets_ce",
         # tag = "v15-11-0-ee",
         image = "registry.gitlab.com/gitlab-org/gitlab/gitlab-assets-ce",
@@ -166,28 +180,31 @@ def fetch_images():
     )
 
     oci_pull(
+        is_bzlmod = is_bzlmod,
         name = "es_kibana_image",
         # tag = "7.16.2",
         image = "docker.elastic.co/kibana/kibana",
         digest = "sha256:9a83bce5d337e7e19d789ee7f952d36d0d514c80987c3d76d90fd1afd2411a9a",
         platforms = [
             "linux/amd64",
-            "linux/arm64"
+            "linux/arm64",
         ],
     )
 
     oci_pull(
+        is_bzlmod = is_bzlmod,
         name = "quay_clair_image",
         # tag = "4.7.2",
         image = "quay.io/projectquay/clair",
         digest = "sha256:8d38ffa8fad72f4bc2647644284c16491cc2d375602519a1f963f96ccc916276",
         platforms = [
             "linux/amd64",
-            "linux/arm64"
+            "linux/arm64",
         ],
     )
 
     oci_pull(
+        is_bzlmod = is_bzlmod,
         name = "nvidia_k8s_device_plugin_image",
         # tag = "v0.14.4",
         digest = "sha256:19c696958fe8a63676ba26fa57114c33149168bbedfea246fc55e0e665c03098",

--- a/oci/extensions.bzl
+++ b/oci/extensions.bzl
@@ -15,7 +15,11 @@ pull = tag_class(attrs = {
             Exactly one of `tag` and `digest` must be set.
             Since tags are mutable, this is not reproducible, so a warning is printed."""),
     "reproducible": attr.bool(doc = """Set to False to silence the warning about reproducibility when using `tag`.""", default = True),
-    "config": attr.label(doc = "Label to a .docker/config.json file")
+    "config": attr.label(doc = "Label to a .docker/config.json file"),
+    "www_authenticate": attr.bool(
+        doc = "set True to implement WWW-Authenticate",
+        default = False,
+    ),
 })
 
 toolchains = tag_class(attrs = {
@@ -39,6 +43,7 @@ def _oci_extension(module_ctx):
                 tag = pull.tag,
                 reproducible = pull.reproducible,
                 config = pull.config,
+                www_authenticate = pull.www_authenticate,
                 is_bzlmod = True,
             )
         for toolchains in mod.tags.toolchains:

--- a/oci/private/authn.bzl
+++ b/oci/private/authn.bzl
@@ -174,7 +174,7 @@ def _get_token(rctx, state, registry, repository, www_authenticate, toolchain):
     if not www_authenticate:
         return pattern
 
-    crane = "@{}".format(_crane_binary(rctx, toolchain)) if toolchain else "@@{}~oci~{}".format(Label(":authn.bzl").workspace_name, _crane_binary(rctx, "oci"))
+    crane = "@{}".format(_crane_binary(rctx, toolchain)) if toolchain else "@@{}~oci~{}".format(Label(":authn.bzl").workspace_name or "_main", _crane_binary(rctx, "oci"))
     image = "{}/{}".format(registry, repository)
     result = rctx.execute([Label(crane), "auth", "token", image])
     if result.return_code != 0:

--- a/oci/private/pull.bzl
+++ b/oci/private/pull.bzl
@@ -33,6 +33,14 @@ _IMAGE_REFERENCE_ATTRS = {
         doc = "Deprecated. Use DOCKER_CONFIG environment variable or config attribute instead. TODO(2.0): remove",
         allow_single_file = True,
     ),
+    "www_authenticate": attr.bool(
+        doc = "set True to implement WWW-Authenticate",
+        default = False,
+    ),
+    "toolchain": attr.string(
+        doc = "oci toolchain name to use for registry authentication, is empty in bzlmod",
+        default = "",
+    ),
 }
 
 SCHEMA1_ERROR = """\
@@ -198,7 +206,7 @@ def _find_platform_manifest(index_mf, platform_wanted):
     return None
 
 def _oci_pull_impl(rctx):
-    au = authn.new(rctx, _config_path(rctx))
+    au = authn.new(rctx, rctx.attr.www_authenticate, rctx.attr.toolchain, _config_path(rctx))
     downloader = _create_downloader(rctx, au)
 
     manifest, size, digest = downloader.download_manifest(rctx.attr.identifier, "manifest.json")
@@ -296,7 +304,7 @@ def _oci_alias_impl(rctx):
     if not rctx.attr.platforms and not rctx.attr.platform:
         fail("One of 'platforms' or 'platform' must be set")
 
-    au = authn.new(rctx, _config_path(rctx))
+    au = authn.new(rctx, rctx.attr.www_authenticate, rctx.attr.toolchain, _config_path(rctx))
     downloader = _create_downloader(rctx, au)
 
     available_platforms = []

--- a/oci/pull.bzl
+++ b/oci/pull.bzl
@@ -103,7 +103,13 @@ _PLATFORM_TO_BAZEL_CPU = {
     "linux/mips64le": "@platforms//cpu:mips64",
 }
 
-def oci_pull(name, image = None, repository = None, registry = None, platforms = None, digest = None, tag = None, reproducible = True, is_bzlmod = False, config = None, config_path = None):
+def _get_default_toolchain():
+    for r in native.existing_rules().values():
+        if r["kind"] == "crane_repositories":
+            return r["name"][:-len(r["platform"]) - len("_crane_")]
+    fail("No oci toolchain found, please register first", native.existing_rules().values())
+
+def oci_pull(name, image = None, repository = None, registry = None, platforms = None, digest = None, tag = None, reproducible = True, is_bzlmod = False, config = None, config_path = None, www_authenticate = False):
     """Repository macro to fetch image manifest data from a remote docker registry.
 
     To use the resulting image, you can use the `@wkspc` shorthand label, for example
@@ -167,6 +173,7 @@ def oci_pull(name, image = None, repository = None, registry = None, platforms =
 
     platform_to_image = None
     single_platform = None
+    toolchain = "" if is_bzlmod else _get_default_toolchain()
 
     if platforms:
         platform_to_image = {}
@@ -183,6 +190,8 @@ def oci_pull(name, image = None, repository = None, registry = None, platforms =
                 config = config,
                 # TODO(2.0): remove
                 config_path = config_path,
+                toolchain = toolchain,
+                www_authenticate = www_authenticate,
             )
 
             if plat in _PLATFORM_TO_BAZEL_CPU:
@@ -207,6 +216,8 @@ def oci_pull(name, image = None, repository = None, registry = None, platforms =
             config = config,
             # TODO(2.0): remove
             config_path = config_path,
+            toolchain = toolchain,
+            www_authenticate = www_authenticate,
         )
 
     oci_alias(
@@ -225,4 +236,6 @@ def oci_pull(name, image = None, repository = None, registry = None, platforms =
         config = config,
         # TODO(2.0): remove
         config_path = config_path,
+        toolchain = toolchain,
+        www_authenticate = www_authenticate,
     )

--- a/oci/repositories.bzl
+++ b/oci/repositories.bzl
@@ -47,7 +47,7 @@ def _crane_repo_impl(repository_ctx):
         "BUILD.bazel",
         CRANE_BUILD_TMPL.format(
             binary = binary,
-            version = repository_ctx.attr.crane_version
+            version = repository_ctx.attr.crane_version,
         ),
     )
 


### PR DESCRIPTION
Resolves https://github.com/bazel-contrib/rules_oci/issues/422

This pr implements a universal WWW-Authenticate that supports the regular authentication process (done by `crane auth token`).

Difficulty in using a private registry with authentication was a big hurdle in migrating to rules_oci, and I think I solved it.

Need discussed:
- `crane auth token` will only read `$HOME/.docker/config.json` as config, so attr `config` will be ignored when registry use Bearer challenge. This needs to be discussed. (Of course, we can simply let the original _WWW_AUTH address continue to execute the old code.)
- Similar to the previous, `crane auth token` cannot use outer config, attr `config` will be ignored. However, from another point of view, push supports config, which is a very strange thing in itself.