### PR TITLE
chore: upgrade rules_go and gazelle

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,9 +25,9 @@ jobs:
       - id: bazel_6
         run: echo "bazelversion=$(head -n 1 .bazelversion)" >> $GITHUB_OUTPUT
       - id: bazel_5
-        run: echo "bazelversion=5.3.2" >> $GITHUB_OUTPUT
+        run: echo "bazelversion=5.4.0" >> $GITHUB_OUTPUT
     outputs:
-      # Will look like ["<version from .bazelversion>", "5.3.2"]
+      # Will look like ["<version from .bazelversion>", "5.4.0"]
       bazelversions: ${{ toJSON(steps.*.outputs.bazelversion) }}
 
   matrix-prep-os:
@@ -69,21 +69,21 @@ jobs:
         bzlmodEnabled: [true, false]
         exclude:
           # macos is expensive (billed at 10X) so don't test these
-          - os: macos-latest 
+          - os: macos-latest
             folder: e2e/custom_registry
-          - os: macos-latest 
+          - os: macos-latest
             folder: e2e/wasm
-          - os: macos-latest 
+          - os: macos-latest
             folder: e2e/crane_as_registry
-          - os: macos-latest 
+          - os: macos-latest
             folder: e2e/pull
           - os: macos-latest
-            bazelversion: 5.3.2
+            bazelversion: 5.4.0
           # e2e/pull is bzlmod only but it has test for both cases.
           - folder: e2e/pull
             bzlmodEnabled: false
           # Don't test bzlmod with Bazel 5 (not supported)
-          - bazelversion: 5.3.2
+          - bazelversion: 5.4.0
             bzlmodEnabled: true
           # TODO: fix
           - folder: e2e/custom_registry
@@ -122,9 +122,9 @@ jobs:
         if: ${{ matrix.os == 'macos-latest' }}
         uses: atomicjar/testcontainers-cloud-setup-action@main
         with:
-            wait: true
-            token: ${{ secrets.TC_CLOUD_TOKEN }}
-      
+          wait: true
+          token: ${{ secrets.TC_CLOUD_TOKEN }}
+
       - name: Configure Remote Docker Host
         if: ${{ matrix.os == 'macos-latest' }}
         run: echo "DOCKER_HOST=$(grep 'tc.host' ~/.testcontainers.properties | cut -d '=' -f2 | xargs)" >> $GITHUB_ENV
@@ -135,4 +135,3 @@ jobs:
           # Bazelisk will download bazel to here, ensure it is cached between runs.
           XDG_CACHE_HOME: ~/.cache/bazel-repo
         run: bazel --bazelrc=$GITHUB_WORKSPACE/.github/workflows/ci.bazelrc --bazelrc=.bazelrc test ${{ steps.set_bzlmod_flag.outputs.bzlmod_flag }} //...
-  

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,5 +18,5 @@ use_repo(oci, "oci_crane_registry_toolchains", "oci_crane_toolchains")
 register_toolchains("@oci_crane_toolchains//:all", "@oci_crane_registry_toolchains//:all")
 
 bazel_dep(name = "rules_pkg", version = "0.7.0", dev_dependency = True)
-bazel_dep(name = "gazelle", version = "0.29.0", dev_dependency = True, repo_name = "bazel_gazelle")
+bazel_dep(name = "gazelle", version = "0.35.0", dev_dependency = True, repo_name = "bazel_gazelle")
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.4.1", dev_dependency = True)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,11 +7,12 @@ load(":internal_deps.bzl", "rules_oci_internal_deps")
 
 rules_oci_internal_deps()
 
+## Stardoc
 load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
 
 stardoc_repositories()
 
-# Fetch our "runtime" dependencies which users need as well
+## Setup rules_oci
 load("//oci:dependencies.bzl", "rules_oci_dependencies")
 
 rules_oci_dependencies()
@@ -24,62 +25,44 @@ oci_register_toolchains(
     zot_version = LATEST_ZOT_VERSION,
 )
 
+## Setup bazel-lib
+load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies")
+
+aspect_bazel_lib_dependencies()
+
+## Setup cosign
 load("//cosign:repositories.bzl", "cosign_register_toolchains")
 
 cosign_register_toolchains(name = "oci_cosign")
 
-# For running our own unit tests
+## Setup skylib unittest
 load("@bazel_skylib//lib:unittest.bzl", "register_unittest_toolchains")
 
 register_unittest_toolchains()
 
 load("@container_structure_test//:repositories.bzl", "container_structure_test_register_toolchain")
 
+## Setup container structure test
 container_structure_test_register_toolchain(name = "container_structure_test")
 
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
-
-############################################
-# Gazelle, for generating bzl_library targets
+## Setup rules_go
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 go_rules_dependencies()
 
-go_register_toolchains(version = "1.17.2")
+go_register_toolchains(version = "1.20.5")
+
+## Setup gazelle
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 
 gazelle_dependencies()
 
-# Rules pkg
+## Setup rules_pkg
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 
 rules_pkg_dependencies()
 
-# Belongs to examples
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
-# JS
-http_archive(
-    name = "aspect_rules_js",
-    sha256 = "dda5fee3926e62c483660b35b25d1577d23f88f11a2775e3555b57289f4edb12",
-    strip_prefix = "rules_js-1.6.9",
-    url = "https://github.com/aspect-build/rules_js/archive/refs/tags/v1.6.9.tar.gz",
-)
-
-load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
-
-rules_js_dependencies()
-
-load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies")
-
-# Workaround for Bazel 5 support
-aspect_bazel_lib_dependencies(override_local_config_platform = True)
-
-load("@rules_nodejs//nodejs:repositories.bzl", "DEFAULT_NODE_VERSION", "nodejs_register_toolchains")
-
-nodejs_register_toolchains(
-    name = "nodejs",
-    node_version = DEFAULT_NODE_VERSION,
-)
+## Unit test repositories
 
 # For sign_external test
 new_local_repository(
@@ -95,6 +78,7 @@ new_local_repository(
     path = "examples/attest_external/workspace",
 )
 
+# For testing fetching from various registries
 load(":fetch.bzl", "fetch_images")
 
 fetch_images()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -28,7 +28,7 @@ oci_register_toolchains(
 ## Setup bazel-lib
 load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies")
 
-aspect_bazel_lib_dependencies()
+aspect_bazel_lib_dependencies(override_local_config_platform = True)
 
 ## Setup cosign
 load("//cosign:repositories.bzl", "cosign_register_toolchains")

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -15,19 +15,19 @@ def rules_oci_internal_deps():
 
     http_archive(
         name = "io_bazel_rules_go",
-        sha256 = "099a9fb96a376ccbbb7d291ed4ecbdfd42f6bc822ab77ae6f1b5cb9e914e94fa",
+        sha256 = "80a98277ad1311dacd837f9b16db62887702e9f1d1c4c9f796d0121a46c8e184",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.35.0/rules_go-v0.35.0.zip",
-            "https://github.com/bazelbuild/rules_go/releases/download/v0.35.0/rules_go-v0.35.0.zip",
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.46.0/rules_go-v0.46.0.zip",
+            "https://github.com/bazelbuild/rules_go/releases/download/v0.46.0/rules_go-v0.46.0.zip",
         ],
     )
 
     http_archive(
         name = "bazel_gazelle",
-        sha256 = "de69a09dc70417580aabf20a28619bb3ef60d038470c7cf8442fafcf627c21cb",
+        integrity = "sha256-MpOL2hbmcABjA1R5Bj2dJMYO2o15/Uc5Vj9Q0zHLMgk=",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz",
-            "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.35.0/bazel-gazelle-v0.35.0.tar.gz",
+            "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.35.0/bazel-gazelle-v0.35.0.tar.gz",
         ],
     )
 
@@ -49,7 +49,6 @@ def rules_oci_internal_deps():
         sha256 = "0a466b61f331585f06ecdbbf2480b9edf70e067a53f261e0596acd573a7d2dc3",
         urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-gazelle-plugin-1.4.1.tar.gz"],
     )
-
 
     http_archive(
         name = "io_bazel_stardoc",


### PR DESCRIPTION
Removes unused rules_js dependency. 

Prefactor for #533 