### PR TITLE
feat(oci_pull): expose the digest as a file

### DIFF
--- a/e2e/pull/wksp/BUILD.bazel
+++ b/e2e/pull/wksp/BUILD.bazel
@@ -1,4 +1,6 @@
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push")
+load("@aspect_bazel_lib//lib:diff_test.bzl", "diff_test")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
 
 oci_image(
     name = "empty",
@@ -11,4 +13,18 @@ oci_push(
     image = ":empty",
     remote_tags = ["latest"],
     repository = "localhost/empty_image",
+)
+
+write_file(
+    name = "want_digest_contents",
+    out = "want_image_digest.json",
+    content = [
+        "sha256:2d4595bbc0fabeb1489b1071f56c26f44a2f495afaa9386ad7d24e7b3d8dfd3e",
+    ],
+)
+
+diff_test(
+    name = "check_they_match",
+    file1 = "want_digest_contents",
+    file2 = "@empty_image//:digest",
 )

--- a/e2e/pull/wksp/MODULE.bazel
+++ b/e2e/pull/wksp/MODULE.bazel
@@ -2,6 +2,8 @@
 
 bazel_dep(name = "rules_oci", version = "0.0.0", dev_dependency = True)
 bazel_dep(name = "platforms", version = "0.0.7")
+bazel_dep(name = "bazel_skylib", version = "1.5.0")
+bazel_dep(name = "aspect_bazel_lib", version = "2.1.0")
 
 local_path_override(
     module_name = "rules_oci",

--- a/oci/private/pull.bzl
+++ b/oci/private/pull.bzl
@@ -345,7 +345,7 @@ def _oci_alias_impl(rctx):
     available_platforms = []
 
     manifest, _, digest = downloader.download_manifest(rctx.attr.identifier, "mf.json")
-    rctx.file("digest.txt", digest + "\n")
+    rctx.file("digest.txt", digest)
 
     if rctx.attr.platforms:
         if manifest["mediaType"] in _SUPPORTED_MEDIA_TYPES["index"]:

--- a/oci/private/pull.bzl
+++ b/oci/private/pull.bzl
@@ -303,8 +303,9 @@ oci_pull = repository_rule(
 )
 
 _MULTI_PLATFORM_IMAGE_ALIAS_TMPL = """\
-exports_files(
-    ["digest"],
+filegroup(
+    name = "digest",
+    srcs = ["digest"],
     visibility = ["//visibility:public"],
 )
 
@@ -319,8 +320,9 @@ alias(
 """
 
 _SINGLE_PLATFORM_IMAGE_ALIAS_TMPL = """\
-exports_files(
-    ["digest"],
+filegroup(
+    name = "digest",
+    srcs = ["digest"],
     visibility = ["//visibility:public"],
 )
 

--- a/oci/private/pull.bzl
+++ b/oci/private/pull.bzl
@@ -303,6 +303,11 @@ oci_pull = repository_rule(
 )
 
 _MULTI_PLATFORM_IMAGE_ALIAS_TMPL = """\
+exports_files(
+    ["image.digest"],
+    visibility = ["//visibility:public"],
+)
+
 alias(
     name = "{target_name}",
     actual = select(
@@ -314,6 +319,11 @@ alias(
 """
 
 _SINGLE_PLATFORM_IMAGE_ALIAS_TMPL = """\
+exports_files(
+    ["image.digest"],
+    visibility = ["//visibility:public"],
+)
+
 alias(
     name = "{target_name}",
     actual = "@{original}//:{original}",
@@ -333,6 +343,7 @@ def _oci_alias_impl(rctx):
     available_platforms = []
 
     manifest, _, digest = downloader.download_manifest(rctx.attr.identifier, "mf.json")
+    rctx.file("image.digest", digest)
 
     if rctx.attr.platforms:
         if manifest["mediaType"] in _SUPPORTED_MEDIA_TYPES["index"]:

--- a/oci/private/pull.bzl
+++ b/oci/private/pull.bzl
@@ -304,7 +304,7 @@ oci_pull = repository_rule(
 
 _MULTI_PLATFORM_IMAGE_ALIAS_TMPL = """\
 exports_files(
-    ["image.digest"],
+    ["digest"],
     visibility = ["//visibility:public"],
 )
 
@@ -320,7 +320,7 @@ alias(
 
 _SINGLE_PLATFORM_IMAGE_ALIAS_TMPL = """\
 exports_files(
-    ["image.digest"],
+    ["digest"],
     visibility = ["//visibility:public"],
 )
 
@@ -343,7 +343,7 @@ def _oci_alias_impl(rctx):
     available_platforms = []
 
     manifest, _, digest = downloader.download_manifest(rctx.attr.identifier, "mf.json")
-    rctx.file("image.digest", digest)
+    rctx.file("digest", digest + "\n")
 
     if rctx.attr.platforms:
         if manifest["mediaType"] in _SUPPORTED_MEDIA_TYPES["index"]:

--- a/oci/private/pull.bzl
+++ b/oci/private/pull.bzl
@@ -305,7 +305,7 @@ oci_pull = repository_rule(
 _MULTI_PLATFORM_IMAGE_ALIAS_TMPL = """\
 filegroup(
     name = "digest",
-    srcs = ["digest"],
+    srcs = ["digest.txt"],
     visibility = ["//visibility:public"],
 )
 
@@ -322,7 +322,7 @@ alias(
 _SINGLE_PLATFORM_IMAGE_ALIAS_TMPL = """\
 filegroup(
     name = "digest",
-    srcs = ["digest"],
+    srcs = ["digest.txt"],
     visibility = ["//visibility:public"],
 )
 
@@ -345,7 +345,7 @@ def _oci_alias_impl(rctx):
     available_platforms = []
 
     manifest, _, digest = downloader.download_manifest(rctx.attr.identifier, "mf.json")
-    rctx.file("digest", digest + "\n")
+    rctx.file("digest.txt", digest + "\n")
 
     if rctx.attr.platforms:
         if manifest["mediaType"] in _SUPPORTED_MEDIA_TYPES["index"]:


### PR DESCRIPTION
This makes the external image repos also expose the digest file, similarly how
the `oci_image` creates a `.digest` target. The actual name of the file can be
something else and I am just putting this out to initiate a discussion.

Let's say a user has `@alpine` image defined via `oci_pull`, they can access the
digest of the upstream image by accessing the `@alpine//:image.digest` file.
We could similarly have the platforms of the image written to a file as well,
but I am not sure if that is useful.

Having the `image.digest` in a file could be useful for various automation that
is done using `write_source_file` rule where one would use a `genrule` to get
the `digest` value from the `@alpine//:image.digest` target, transform it and
output it to a file that is later synced with `write_source_file`. Not needing
to depend on extra CLIs that might not be available to the user of `rules_oci`
as toolchains could be good here.
