### PR TITLE
fix: Add quay back to authn config 

### DIFF
--- a/oci/private/authn.bzl
+++ b/oci/private/authn.bzl
@@ -48,6 +48,11 @@ _WWW_AUTH = {
         "scope": "repository:{repository}:pull",
         "service": "token-service",
     },
+    "quay.io": {
+        "realm": "{registry}/v2/auth",
+        "scope": "repository:{repository}:pull",
+        "service": "{registry}",
+    },
 }
 
 def _strip_host(url):


### PR DESCRIPTION
Looks like the quay config got lost when refactoring `pull.bzl` to `authn.bzl` this PR adds it back

