### PR TITLE
Draft: add container_run_and_save rule

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -21,3 +21,13 @@ bzl_library(
         "@bazel_tools//tools/build_defs/repo:utils.bzl",
     ],
 )
+
+bzl_library(
+    name = "fetch",
+    srcs = ["fetch.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "@rules_oci//oci:pull",
+    ],
+)

--- a/cosign/private/BUILD.bazel
+++ b/cosign/private/BUILD.bazel
@@ -11,21 +11,15 @@ exports_files([
 ])
 
 bzl_library(
-    name = "sign",
-    srcs = ["sign.bzl"],
-    visibility = [
-        "//cosign:__subpackages__",
-        "//docs:__pkg__",
-    ],
+    name = "attest",
+    srcs = ["attest.bzl"],
+    visibility = ["//cosign:__subpackages__"],
 )
 
 bzl_library(
-    name = "attest",
-    srcs = ["attest.bzl"],
-    visibility = [
-        "//cosign:__subpackages__",
-        "//docs:__pkg__",
-    ],
+    name = "sign",
+    srcs = ["sign.bzl"],
+    visibility = ["//cosign:__subpackages__"],
 )
 
 bzl_library(

--- a/examples/run_commands/BUILD
+++ b/examples/run_commands/BUILD
@@ -1,0 +1,37 @@
+load("//oci:defs.bzl", "oci_image", "oci_tarball", "container_run_and_save")
+
+oci_image(
+    name = "example_ubuntu_base",
+    base = "@ubuntu",
+    entrypoint = ["/bin/bash", "-c"],
+    env = {
+        "TZDATA": "Etc/Utc",
+        "DEBIAN_FRONTEND": "noninteractive",
+    },
+)
+
+oci_tarball(
+    name = "example_ubuntu_base_tarball",
+    image = ":example_ubuntu_base",
+    repo_tags = ["example-ubuntu-base:latest"]
+)
+
+container_run_and_save(
+    name = "update_packages",
+    base_tarball = ":example_ubuntu_base_tarball",
+    cmd = "apt update; apt upgrade -y"
+)
+
+oci_image(
+    name = "image",
+    base = ":example_ubuntu_base",
+    tars = [
+        ":update_packages",
+    ]
+)
+
+oci_tarball(
+    name = "tarball",
+    image = ":image",
+    repo_tags = ["updated-ubuntu-base:latest"]
+)

--- a/examples/run_commands/README.md
+++ b/examples/run_commands/README.md
@@ -1,0 +1,75 @@
+# Running a command (Dockerfile RUN equivalent)
+
+Shows how to update a base Ubuntu image using `container_run_and_save` rule.
+
+
+## Before command (packages available)
+```
+$ bazel run //examples/run_commands:example_ubuntu_base_tarball
+INFO: Analyzed target //examples/run_commands:example_ubuntu_base_tarball (0 packages loaded, 0 targets configured).
+INFO: Found 1 target...
+Target //examples/run_commands:example_ubuntu_base_tarball up-to-date:
+  bazel-bin/examples/run_commands/example_ubuntu_base_tarball/tarball.tar
+INFO: Elapsed time: 0.211s, Critical Path: 0.02s
+INFO: 4 processes: 4 internal.
+INFO: Build completed successfully, 4 total actions
+INFO: Running command line: bazel-bin/examples/run_commands/example_ubuntu_base_tarball.sh
+Loaded image: example-ubuntu-base:latest
+```
+
+```
+ubuntu@ip-10-4-33-28:/grail/src/teams/beng/docker-images/allimages$ docker run --rm -it example-ubuntu-base:latest bash
+root@0b0c7d39bed5:/# apt update; apt upgrade
+Get:1 http://archive.ubuntu.com/ubuntu jammy InRelease [270 kB]
+[...]
+Get:18 http://security.ubuntu.com/ubuntu jammy-security/multiverse amd64 Packages [44.7 kB]
+Fetched 31.4 MB in 4s (6970 kB/s)
+Reading package lists... Done
+Building dependency tree... Done
+Reading state information... Done
+42 packages can be upgraded. Run 'apt list --upgradable' to see them.
+Reading package lists... Done
+Building dependency tree... Done
+Reading state information... Done
+Calculating upgrade... Done
+The following packages will be upgraded:
+  apt base-files bash bsdutils coreutils dpkg gcc-12-base libapt-pkg6.0 libblkid1 libc-bin libc6 libcap2 libgcc-s1 libgnutls30 libgssapi-krb5-2 libk5crypto3 libkrb5-3
+  libkrb5support0 libmount1 libncurses6 libncursesw6 libpam-modules libpam-modules-bin libpam-runtime libpam0g libprocps8 libsmartcols1 libssl3 libstdc++6 libsystemd0 libtinfo6
+  libudev1 libuuid1 login mount ncurses-base ncurses-bin passwd perl-base procps tar util-linux
+42 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
+Need to get 20.4 MB of archives.
+After this operation, 33.8 kB of additional disk space will be used.
+Do you want to continue? [Y/n] 
+```
+
+## After command (no packages available)
+```
+$ bazel run //examples/run_commands:tarball
+INFO: Analyzed target //examples/run_commands:tarball (0 packages loaded, 0 targets configured).
+INFO: Found 1 target...
+Target //examples/run_commands:tarball up-to-date:
+  bazel-bin/examples/run_commands/tarball/tarball.tar
+INFO: Elapsed time: 0.210s, Critical Path: 0.01s
+INFO: 1 process: 1 internal.
+INFO: Build completed successfully, 1 total action
+INFO: Running command line: bazel-bin/examples/run_commands/tarball.sh
+Loaded image: updated-ubuntu-base:latest
+```
+
+```
+$ docker run --rm -it  updated-debian-base:latest bash 
+root@196d67f6c4f4:/# apt update; apt upgrade
+Hit:1 http://security.ubuntu.com/ubuntu jammy-security InRelease
+Hit:2 http://archive.ubuntu.com/ubuntu jammy InRelease
+Hit:3 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
+Hit:4 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
+Reading package lists... Done
+Building dependency tree... Done
+Reading state information... Done
+All packages are up to date.
+Reading package lists... Done
+Building dependency tree... Done
+Reading state information... Done
+Calculating upgrade... Done
+0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
+```

--- a/oci/BUILD.bazel
+++ b/oci/BUILD.bazel
@@ -69,6 +69,16 @@ bzl_library(
 )
 
 bzl_library(
+    name = "extensions",
+    srcs = ["extensions.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":pull",
+        ":repositories",
+    ],
+)
+
+bzl_library(
     name = "toolchain",
     srcs = ["toolchain.bzl"],
     visibility = ["//visibility:public"],

--- a/oci/defs.bzl
+++ b/oci/defs.bzl
@@ -16,11 +16,13 @@ load("//oci/private:image.bzl", _oci_image = "oci_image")
 load("//oci/private:image_index.bzl", _oci_image_index = "oci_image_index")
 load("//oci/private:push.bzl", _oci_push = "oci_push")
 load("//oci/private:tarball.bzl", _oci_tarball = "oci_tarball")
+load("//oci/private:container_run_and_save.bzl", _container_run_and_save = "container_run_and_save")
 
 oci_tarball_rule = _oci_tarball
 oci_image_rule = _oci_image
 oci_image_index = _oci_image_index
 oci_push_rule = _oci_push
+container_run_and_save_rule = _container_run_and_save
 
 def oci_image(name, labels = None, annotations = None, env = None, cmd = None, entrypoint = None, exposed_ports = None, **kwargs):
     """Macro wrapper around [oci_image_rule](#oci_image_rule).
@@ -208,4 +210,29 @@ def oci_tarball(name, repo_tags = None, **kwargs):
         name = name,
         repo_tags = repo_tags,
         **kwargs
+    )
+
+def container_run_and_save(name, base_tarball = None, cmd = None, repo_tags = None, **kwargs):
+    """Macro wrapper around [container_run_and_save](#container_run_and_save)
+
+    Allows for execution of commands in a given image, exporting the resulting layers
+    in a tarfile. This produces a format in which [oci_tarball_rule](#oci_tarball_rule) expects.
+
+    Args:
+        name: name of resulting container_run_and_save rule
+        base_tarball: label to a DefaultFile containing a tarball from which the executing container
+            will be based on.
+        cmd: Command to execute in the executing environment.
+        **kwargs: other named arguments to [oci_tarball_rule](#oci_tarball_rule) and
+            [common rule attributes](https://bazel.build/reference/be/common-definitions#common-attributes).
+    """
+
+    forwarded_kwargs = propagate_common_rule_attributes(kwargs)
+
+    container_run_and_save_rule(
+        name = name,
+        base_tarball = base_tarball,
+        cmd = cmd,
+        repo_tags = repo_tags,
+        **forwarded_kwargs
     )

--- a/oci/private/BUILD.bazel
+++ b/oci/private/BUILD.bazel
@@ -31,15 +31,6 @@ bzl_library(
 )
 
 bzl_library(
-    name = "image_index",
-    srcs = ["image_index.bzl"],
-    visibility = [
-        "//docs:__pkg__",
-        "//oci:__subpackages__",
-    ],
-)
-
-bzl_library(
     name = "pull",
     srcs = ["pull.bzl"],
     visibility = [
@@ -67,21 +58,6 @@ bzl_library(
 )
 
 bzl_library(
-    name = "toolchains_repo",
-    srcs = ["toolchains_repo.bzl"],
-    visibility = [
-        "//cosign:__subpackages__",
-        "//oci:__subpackages__",
-    ],
-)
-
-bzl_library(
-    name = "versions",
-    srcs = ["versions.bzl"],
-    visibility = ["//oci:__subpackages__"],
-)
-
-bzl_library(
     name = "download",
     srcs = ["download.bzl"],
     visibility = ["//oci:__subpackages__"],
@@ -104,4 +80,29 @@ bzl_library(
     srcs = ["util.bzl"],
     visibility = ["//oci:__subpackages__"],
     deps = ["@bazel_skylib//lib:versions"],
+)
+
+bzl_library(
+    name = "container_run_and_save",
+    srcs = ["container_run_and_save.bzl"],
+    visibility = ["//oci:__subpackages__"],
+    deps = ["@bazel_skylib//lib:versions"],
+)
+
+bzl_library(
+    name = "image_index",
+    srcs = ["image_index.bzl"],
+    visibility = ["//oci:__subpackages__"],
+)
+
+bzl_library(
+    name = "toolchains_repo",
+    srcs = ["toolchains_repo.bzl"],
+    visibility = ["//oci:__subpackages__"],
+)
+
+bzl_library(
+    name = "versions",
+    srcs = ["versions.bzl"],
+    visibility = ["//oci:__subpackages__"],
 )

--- a/oci/private/container_run_and_save.bzl
+++ b/oci/private/container_run_and_save.bzl
@@ -1,0 +1,81 @@
+def _container_run_and_save_impl(ctx):
+    name = ctx.label.name
+    base_tarball = ctx.attr.base_tarball
+
+    tar_output = ctx.actions.declare_file("layer_%s.tar" % name)
+
+    script_output = ctx.actions.declare_file("run_%s.sh" % name)
+
+    file_list = []
+    file_list_str = []
+
+    for i in base_tarball[DefaultInfo].files.to_list():
+        if "tar" in i.path:
+            file_list.append(i)
+            file_list_str.append(i.path)
+
+    ctx.actions.expand_template(
+        template = ctx.file._run_sh_tpl,
+        output = script_output,
+        is_executable = True,
+        substitutions = {
+            "{{base_image_tarball}}": " ".join(file_list_str),
+            "{{container_name}}": "%s_container" % name,
+            "{{command}}": ctx.attr.cmd,
+            "{{output}}": tar_output.path,
+            "{{docker_buildkit}}": "1" if ctx.attr.buildkit else "0",
+            "{{loader}}":  ctx.file.loader.path if ctx.file.loader else "",
+        },
+    )
+
+    ctx.actions.run(
+        executable = script_output,
+        outputs = [tar_output],
+        mnemonic = "OCIExecLayer",
+        tools = file_list,
+    )
+
+    return [
+        DefaultInfo(
+            files = depset([tar_output]),
+            executable = tar_output,
+        ),
+    ]
+
+_container_run_and_save_attrs = {
+    "base_tarball": attr.label(allow_single_file = True),
+    "cmd": attr.string(
+        doc = """\
+            Command to execute inside of the container.
+        """,
+        mandatory = True,
+    ),
+    "buildkit": attr.bool(
+        doc = """\
+            Enable/disable the use of BuildKit when running.
+        """,
+        mandatory = False,
+        default = True
+    ),
+    "loader": attr.label(
+        doc = """\
+            Alternative target for a container cli tool that will be
+            used to load the image into the local engine when using `bazel run` on this container_run_and_save.
+
+            By default, we look for `docker` or `podman` on the PATH, and run the `load` command.
+
+            See the _run_sh_tpl attribute for the script that calls this loader tool.
+            """,
+        allow_single_file = True,
+        mandatory = False,
+        executable = True,
+        cfg = "target",
+    ),
+    "_run_sh_tpl": attr.label(default = "container_run_and_save.sh.tpl", allow_single_file = True),
+}
+
+container_run_and_save = rule(
+    implementation = _container_run_and_save_impl,
+    attrs = _container_run_and_save_attrs,
+    executable = True,
+)

--- a/oci/private/container_run_and_save.sh.tpl
+++ b/oci/private/container_run_and_save.sh.tpl
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -o pipefail -o errexit -o nounset
+
+readonly DOCKER_BUILDKIT="{{docker_buildkit}}"
+readonly CONTAINER_NAME="{{container_name}}"
+readonly IMAGE_TAR="{{base_image_tarball}}"
+
+if [ -e "{{loader}}" ]; then
+    CONTAINER_CLI="{{loader}}"
+elif command -v docker &> /dev/null; then
+    CONTAINER_CLI="docker"
+elif command -v podman &> /dev/null; then
+    CONTAINER_CLI="podman"
+else
+    echo >&2 "Neither docker or podman could be found."
+    echo >&2 "To use a different container runtime, pass an executable to the 'loader' attribute of oci_tarball."
+    exit 1
+fi
+
+function is_container_running () {
+    container_name=${1:-""}
+    (docker ps --filter=name=${container_name} | grep -q ${container_name}) && return 0 || return 1
+}
+
+if [[ $(is_container_running $CONTAINER_NAME) -eq 0 ]]; then
+    "${CONTAINER_CLI}" rm -f ${CONTAINER_NAME} 2>/dev/null || true
+fi
+
+IMAGE_NAME=$(docker load --quiet --input $IMAGE_TAR | grep -v 'already exists' | sed -e 's/Loaded image\: //g')
+"${CONTAINER_CLI}" run --name $CONTAINER_NAME $IMAGE_NAME '{{command}}'
+
+docker_container_tag="${CONTAINER_NAME}"
+
+"${CONTAINER_CLI}" commit $CONTAINER_NAME $docker_container_tag
+
+"${CONTAINER_CLI}" export $docker_container_tag --output={{output}}
+
+if [[ $(is_container_running $CONTAINER_NAME) -eq 0 ]]; then
+    "${CONTAINER_CLI}" rm -f ${CONTAINER_NAME} 2>/dev/null || true
+fi


### PR DESCRIPTION
# Overview
Adds `container_run_and_save` rule. This rule is meant to be a mediocre "replacement" for the `container_run_and_commit` rule out of `rules_docker`.

## Why?
* Few/no replacements exist for `container_run_and_*` rules offered by `rules_docker`
* `rules_docker` is not actively maintained
* Updating a base image such as Ubuntu may not be as easy as decompressing debs in the event of widespread dependency requirements (glibc/etc)

## Concessions/Caveats
* Uses similar exec fallback as `oci_tarball`
  * Attempts to find a binary via `loader` parameter, falls back to $PATH if missing
* Must pass a tarfile as a base image to the `container_run_and_save` rule.
  * Ideally this would just be passing in a label to an `oci_image` like other rules
* There are probably other/better ways to do this
  * This works ™️ 
  * This provides an option for people coming from `rules_docker` who need to execute commands in their containers
  * This provides a workaround for a well-known issues in `rules_oci` which is the lack of this and similar rules matching `rules_docker` functionality
* This probably does less than `rules_docker` implementation
  * Something is better than nothing

### Other thoughts
* If this is something that the maintainers would like to avoid the overhead on maintaining and supporting, I would ask to then consider creating these files as a patch which can then be optionally applied in a WORKSPACE file. This would allow for the feature to exist but obviate the need to support it as a GA feature.
* `gazelle` did it's thing and touched a few more corners of this than I was intending. I can revert these changes if desired.

# Usage
```
oci_image(
    name = "example_ubuntu_base",
    base = "@ubuntu",
    entrypoint = ["/bin/bash", "-c"],
    env = {
        "TZDATA": "Etc/Utc",
        "DEBIAN_FRONTEND": "noninteractive",
    },
)

oci_tarball(
    name = "example_ubuntu_base_tarball",
    image = ":example_ubuntu_base",
    repo_tags = ["example-ubuntu-base:latest"]
)

container_run_and_save(
    name = "update_packages",
    base_tarball = ":example_ubuntu_base_tarball",
    cmd = "apt update; apt upgrade -y"
)

oci_image(
    name = "image",
    base = ":example_ubuntu_base",
    tars = [
        ":update_packages",
    ]
)

oci_tarball(
    name = "tarball",
    image = ":image",
    repo_tags = ["updated-ubuntu-base:latest"]
)
```

Produces an image which is up to date and compliant with basic security scans:
```
$ docker run --rm -it  updated-debian-base:latest "sh -c 'apt update; apt upgrade'"
Hit:1 http://archive.ubuntu.com/ubuntu jammy InRelease
Get:2 http://security.ubuntu.com/ubuntu jammy-security InRelease [110 kB]
Get:3 http://archive.ubuntu.com/ubuntu jammy-updates InRelease [119 kB]
Hit:4 http://archive.ubuntu.com/ubuntu jammy-backports InRelease    
Get:5 http://archive.ubuntu.com/ubuntu jammy-updates/universe amd64 Packages [1370 kB]
Get:6 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 Packages [2035 kB]                                                                                                 
Fetched 3634 kB in 8s (444 kB/s)                                                                                                                                                   
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
All packages are up to date.
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Calculating upgrade... Done
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
```