### PR TITLE
Fix #552 and update readme

### DIFF
--- a/docs/cpp.md
+++ b/docs/cpp.md
@@ -39,10 +39,10 @@ pkg_tar(
 # Making image
 # C++ programs usually need some fundamental libraries such as glibc, libstdc++, etc.
 # Correspondigly, use language-specific distroless images.
-# Here we use gcr.io/distroless/cc-debian12 image for this C++ program.
+# Here we usedocker.io/library/ubuntu image for this C++ program.
 oci_image(
     name = "image",
-    base = "@distroless_cc_debian12",
+    base = "@docker_lib_ubuntu",
     tars = [":tar"],
     entrypoint = ["/example_binary"],
 )
@@ -60,17 +60,16 @@ In `MODULE.bazel` file, be sure to add the following sections:
 ```python
 # Pull needed base image
 oci.pull(
-    name = "distroless_cc_debian12",
-    image = "gcr.io/distroless/cc-debian12",
+    name = "docker_lib_ubuntu",
+    image = "docker.io/library/ubuntu",
     platforms = [
-        "linux/amd64",
-        "linux/arm/v7",
         "linux/arm64/v8",
+        "linux/amd64",
     ],
-    tag = "latest",
+    tag = "rolling",
 )
 # Expose the base image
-use_repo(oci, "distroless_cc_debian12")
+use_repo(oci, "docker_lib_ubuntu")
 ```
 ```python
 # Import rules_pkg

--- a/docs/cpp.md
+++ b/docs/cpp.md
@@ -39,7 +39,7 @@ pkg_tar(
 # Making image
 # C++ programs usually need some fundamental libraries such as glibc, libstdc++, etc.
 # Correspondigly, use language-specific distroless images.
-# Here we usedocker.io/library/ubuntu image for this C++ program.
+# Here we use docker.io/library/ubuntu image for this C++ program.
 oci_image(
     name = "image",
     base = "@docker_lib_ubuntu",


### PR DESCRIPTION
docker.io/library/ubuntu contains required toolchain. GCR is no longer maintained and is shutting down [link](https://cloud.google.com/artifact-registry/docs/transition/prepare-gcr-shutdown?_gl=1*tkwscz*_ga*MTE3Njk2NzAxMy4xNzA4ODQ1NjQw*_ga_WH2QY8WWF5*MTcxNDk0MTI5My43OC4xLjE3MTQ5NDEzMDAuMC4wLjA.&_ga=2.246388676.-1176967013.1708845640&_gac=1.253163003.1714817497.Cj0KCQjwudexBhDKARIsAI-GWYVhO6QleeFT7rzyBWZvb2pi9bksKKOkNxgd826LvJNFz3D2oSZ4LasaAujoEALw_wcB), so that's another reason for this doc update.