### PR TITLE
Reduce GHA caching

### DIFF
--- a/.github/workflows/ci.bazelrc
+++ b/.github/workflows/ci.bazelrc
@@ -4,8 +4,8 @@
 # Debug where options came from
 build --announce_rc
 # This directory is configured in GitHub actions to be persisted between runs.
-build --disk_cache=~/.cache/bazel
 build --repository_cache=~/.cache/bazel-repo
+
 # Don't rely on test logs being easily accessible from the test runner,
 # though it makes the log noisier.
 test --test_output=errors

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,7 +96,6 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            ~/.cache/bazel
             ~/.cache/bazel-repo
           key: bazel-cache-${{ matrix.os }}-${{ matrix.folder }}-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'WORKSPACE') }}
           restore-keys: |


### PR DESCRIPTION
The --disk_cache flag produces large outputs and causes flaky CI when we run out of disk.