### PR TITLE
oci_push to support Windows builds

### DIFF
--- a/oci/private/BUILD.bazel
+++ b/oci/private/BUILD.bazel
@@ -103,5 +103,8 @@ bzl_library(
     name = "util",
     srcs = ["util.bzl"],
     visibility = ["//oci:__subpackages__"],
-    deps = ["@bazel_skylib//lib:versions"],
+    deps = [
+        "@bazel_skylib//lib:paths",
+        "@bazel_skylib//lib:versions",
+    ],
 )

--- a/oci/private/push.bzl
+++ b/oci/private/push.bzl
@@ -128,6 +128,7 @@ _attrs = {
         default = "push.sh.tpl",
         allow_single_file = True,
     ),
+    "_windows_constraint": attr.label(default = "@platforms//os:windows"),
 }
 
 def _quote_args(args):
@@ -178,7 +179,7 @@ def _impl(ctx):
     runfiles = runfiles.merge(yq.default.default_runfiles)
     runfiles = runfiles.merge(crane.default.default_runfiles)
 
-    return DefaultInfo(executable = executable, runfiles = runfiles)
+    return DefaultInfo(executable = util.maybe_wrap_launcher_for_windows(ctx, executable), runfiles = runfiles)
 
 oci_push_lib = struct(
     implementation = _impl,
@@ -186,6 +187,7 @@ oci_push_lib = struct(
     toolchains = [
         "@rules_oci//oci:crane_toolchain_type",
         "@aspect_bazel_lib//lib:yq_toolchain_type",
+        "@bazel_tools//tools/sh:toolchain_type",
     ],
 )
 

--- a/oci/private/util.bzl
+++ b/oci/private/util.bzl
@@ -160,8 +160,6 @@ if defined args (
   set args=!args:\=\\\\!
   set args=!args:"=\"!
 )
-echo !launcher!
-echo !args!
 "{bash_bin}" -c "%parent_dir%{launcher} --verbose !args!"
 """.format(
             bash_bin = ctx.toolchains["@bazel_tools//tools/sh:toolchain_type"].path,

--- a/oci/private/util.bzl
+++ b/oci/private/util.bzl
@@ -160,7 +160,7 @@ if defined args (
   set args=!args:\=\\\\!
   set args=!args:"=\"!
 )
-"{bash_bin}" -c "%parent_dir%{launcher} --verbose !args!"
+"{bash_bin}" -c "%parent_dir%{launcher} !args!"
 """.format(
             bash_bin = ctx.toolchains["@bazel_tools//tools/sh:toolchain_type"].path,
             launcher = paths.relativize(bash_launcher.path, win_launcher.dirname),

--- a/oci/private/util.bzl
+++ b/oci/private/util.bzl
@@ -4,7 +4,7 @@ load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:versions.bzl", "versions")
 
 _IMAGE_PLATFORM_VARIANT_DEFAULTS = {
-    "linux/arm64": "v8",
+    'linux/arm64': 'v8',
 }
 
 def _parse_image(image):
@@ -115,12 +115,12 @@ def _validate_image_platform(rctx, image_config):
     attr_variant_or_default = attr_variant or _IMAGE_PLATFORM_VARIANT_DEFAULTS.get(rctx.attr.platform, None)
     image_variant_or_default = image_variant or _IMAGE_PLATFORM_VARIANT_DEFAULTS.get(image_os + "/" + image_architecture, None)
     if image_variant_or_default != attr_variant_or_default:
-        fail("Image {}/{} has platform variant '{}', but 'platforms' attribute specifies variant '{}'".format(
-            rctx.attr.registry,
-            rctx.attr.repository,
-            image_variant,
-            attr_variant,
-        ))
+            fail("Image {}/{} has platform variant '{}', but 'platforms' attribute specifies variant '{}'".format(
+                rctx.attr.registry,
+                rctx.attr.repository,
+                image_variant,
+                attr_variant,
+            ))
 
 def _warning(rctx, message):
     rctx.execute([
@@ -176,7 +176,7 @@ def _file_exists(rctx, path):
     result = rctx.execute(["stat", path])
     return result.return_code == 0
 
-_INDEX_JSON_TMPL = """\
+_INDEX_JSON_TMPL="""\
 {{
    "schemaVersion": 2,
    "mediaType": "application/vnd.oci.image.index.v1+json",
@@ -190,6 +190,7 @@ _INDEX_JSON_TMPL = """\
 }}"""
 
 def _build_manifest_json(media_type, size, digest, platform):
+
     optional_platform = ""
 
     if platform:
@@ -210,7 +211,7 @@ def _build_manifest_json(media_type, size, digest, platform):
         media_type,
         size,
         digest,
-        optional_platform = optional_platform,
+        optional_platform = optional_platform
     )
 
 def _assert_crane_version_at_least(ctx, at_least, rule):
@@ -226,6 +227,7 @@ def _platform_triplet(platform_str):
         architecture, _, variant = architecture.partition("/")
     return os, architecture, variant
 
+
 util = struct(
     parse_image = _parse_image,
     sha256 = _sha256,
@@ -235,5 +237,5 @@ util = struct(
     file_exists = _file_exists,
     build_manifest_json = _build_manifest_json,
     assert_crane_version_at_least = _assert_crane_version_at_least,
-    platform_triplet = _platform_triplet,
+    platform_triplet = _platform_triplet
 )


### PR DESCRIPTION
This pull request updates `util#_maybe_wrap_launcher_for_windows` to use relative paths to fix `bazel run` failing on Windows with `/usr/bin/bash: line 1: bazel-out/x64_windows-fastbuild/bin/some-project/push_app-image-push.sh: No such file or directory`
and update push.bzl to use `util#maybe_wrap_launcher_for_windows` (fixes #564)