### PR TITLE
fix: canonicalize missing components

### DIFF
--- a/examples/deb/BUILD.bazel
+++ b/examples/deb/BUILD.bazel
@@ -9,26 +9,13 @@ _ARCH = [
 # any other compression algorithm is simply is runtime error.
 # we decompress the tar archive with bsdtar and recompress with a
 # known compression algorithm.
-#
-# TODO: this is slow as it parses the tar archive as well
-# use zstd rule once we have one.
-[
-    genrule(
-        name = "decompress_" + architecture,
-        srcs = ["@bash_{}//:layer".format(architecture)],
-        outs = ["_{}.tar.gz".format(architecture)],
-        cmd = "$(BSDTAR_BIN) --gzip -cf $@ @$<",
-        toolchains = ["@bsd_tar_toolchains//:resolved_toolchain"],
-    )
-    for architecture in _ARCH
-]
 
 [
     oci_image(
         name = "image_" + architecture,
         architecture = architecture,
         os = "linux",
-        tars = ["_{}.tar.gz".format(architecture)],
+        tars = ["@bash_amd64//:layer"],
     )
     for architecture in _ARCH
 ]

--- a/fetch.bzl
+++ b/fetch.bzl
@@ -31,9 +31,9 @@ def fetch_images():
         ],
     )
 
-    # Pull an image from public ECR. 
+    # Pull an image from public ECR.
     # When --credential_helper is provided, see .bazelrc at workspace root, it will take precende over
-    # auth from oci_pull. However, pulling from public ECR works out of the box so this will never fail 
+    # auth from oci_pull. However, pulling from public ECR works out of the box so this will never fail
     # unless oci_pull's authentication mechanism breaks and --credential_helper is absent.
     oci_pull(
         name = "ecr_lambda_python",
@@ -41,8 +41,8 @@ def fetch_images():
         tag = "3.11.2024.01.25.10",
         platforms = [
             "linux/amd64",
-            "linux/arm64/v8"
-        ]
+            "linux/arm64/v8",
+        ],
     )
 
     # Show that the digest is optional.
@@ -172,7 +172,7 @@ def fetch_images():
         digest = "sha256:9a83bce5d337e7e19d789ee7f952d36d0d514c80987c3d76d90fd1afd2411a9a",
         platforms = [
             "linux/amd64",
-            "linux/arm64"
+            "linux/arm64",
         ],
     )
 
@@ -183,7 +183,7 @@ def fetch_images():
         digest = "sha256:8d38ffa8fad72f4bc2647644284c16491cc2d375602519a1f963f96ccc916276",
         platforms = [
             "linux/amd64",
-            "linux/arm64"
+            "linux/arm64",
         ],
     )
 
@@ -195,9 +195,12 @@ def fetch_images():
     )
 
     _DEB_TO_LAYER = """\
-alias(
+genrule(
     name = "layer",
-    actual = ":data.tar.xz",
+    srcs = [":data.tar.xz"],
+    outs = ["data.tar.zst"],
+    cmd = "$(BSDTAR_BIN) --zstd -cf $@ @$<",
+    toolchains = ["@bsd_tar_toolchains//:resolved_toolchain"],
     visibility = ["//visibility:public"],
 )
 """

--- a/oci/private/image.sh
+++ b/oci/private/image.sh
@@ -104,7 +104,7 @@ function add_layer() {
   digest_path="$(jq -r '.digest | sub(":"; "/")' <<< "$desc")"
 
   if [[ "$USE_TREEARTIFACT_SYMLINKS" == "1" ]]; then
-    relative=$(coreutils realpath --relative-to="$OUTPUT/blobs/sha256" "$path" --no-symlinks)
+    relative=$(coreutils realpath --no-symlinks --canonicalize-missing --relative-to="$OUTPUT/blobs/sha256" "$path" )
     coreutils ln -s "$relative" "$OUTPUT/blobs/$digest_path"
   else
     coreutils cat "$path" > "$OUTPUT/blobs/$digest_path"


### PR DESCRIPTION
In 2.x, tars stopped being direct inputs `OCIImage` actions, this meant that none of the tars passed by the user actually went into the sandbox.  fixes #566 

Imagine an oci_image in `examples/env/image` 

`bazel-out/darwin_arm64-fastbuild/bin/external/bash_amd64/data.tar.zst`  -> did fail because `external` segment does not exist, therefore can't be canonicalized.

`bazel-out/darwin_arm64-fastbuild/bin/examples/env/image/data.tar.zst` -> did NOT fail because all components in the path except the file itself existed, therefore can be canonicalized.

In the scenario above `realpath` failed if any of the directory segments in the path was missing leading to errors only when external repository labels passed to tars.  This fixes the issue by telling `realpath` to ignore missing segments, and we don't care if the file actually exists on disk. 

I changed `examples/deb` a bit so that genrule is in the external repo, providing us a test coverage for this.
