### PR TITLE
Add import_tags attribute to oci_pull

### DIFF
--- a/docs/pull.md
+++ b/docs/pull.md
@@ -94,7 +94,7 @@ See the [examples/credential_helper](/examples/credential_helper/auth.sh) direct
 
 <pre>
 oci_pull(<a href="#oci_pull-name">name</a>, <a href="#oci_pull-image">image</a>, <a href="#oci_pull-repository">repository</a>, <a href="#oci_pull-registry">registry</a>, <a href="#oci_pull-platforms">platforms</a>, <a href="#oci_pull-digest">digest</a>, <a href="#oci_pull-tag">tag</a>, <a href="#oci_pull-reproducible">reproducible</a>, <a href="#oci_pull-is_bzlmod">is_bzlmod</a>, <a href="#oci_pull-config">config</a>,
-         <a href="#oci_pull-config_path">config_path</a>)
+         <a href="#oci_pull-config_path">config_path</a>, <a href="#oci_pull-bazel_tags">bazel_tags</a>)
 </pre>
 
 Repository macro to fetch image manifest data from a remote docker registry.
@@ -123,5 +123,6 @@ in rules like `oci_image`.
 | <a id="oci_pull-is_bzlmod"></a>is_bzlmod |  whether the oci_pull is being called from a module extension   |  <code>False</code> |
 | <a id="oci_pull-config"></a>config |  Label to a <code>.docker/config.json</code> file.   |  <code>None</code> |
 | <a id="oci_pull-config_path"></a>config_path |  Deprecated. use <code>config</code> attribute or DOCKER_CONFIG environment variable.   |  <code>None</code> |
+| <a id="oci_pull-bazel_tags"></a>bazel_tags |  Bazel tags to be propagated to generated rules.   |  <code>[]</code> |
 
 

--- a/oci/private/pull.bzl
+++ b/oci/private/pull.bzl
@@ -178,7 +178,7 @@ copy_to_directory(
         "oci-layout",
         "index.json",
     ],
-    tags = {tags},
+    tags = {bazel_tags},
     visibility = ["//visibility:public"]
 )
 """
@@ -251,11 +251,11 @@ def _oci_pull_impl(rctx):
     ))
     rctx.file("oci-layout", json.encode_indent({"imageLayoutVersion": "1.0.0"}, indent = "    "))
 
-    tags = "[\"{}\"]".format("\", \"".join(rctx.attr.tags))
+    bazel_tags = "[\"{}\"]".format("\", \"".join(rctx.attr.bazel_tags))
 
     rctx.file("BUILD.bazel", content = _BUILD_FILE_TMPL.format(
         target_name = rctx.attr.target_name,
-        tags = tags,
+        bazel_tags = bazel_tags,
     ))
 
 oci_pull = repository_rule(
@@ -269,6 +269,9 @@ oci_pull = repository_rule(
             "target_name": attr.string(
                 doc = "Name given for the image target, e.g. 'image'",
                 mandatory = True,
+            ),
+            "bazel_tags": attr.string_list(
+                doc = "Bazel tags to apply to generated targets of this rule",
             ),
         },
     ),

--- a/oci/private/pull.bzl
+++ b/oci/private/pull.bzl
@@ -178,6 +178,7 @@ copy_to_directory(
         "oci-layout",
         "index.json",
     ],
+    tags = {tags},
     visibility = ["//visibility:public"]
 )
 """
@@ -250,8 +251,11 @@ def _oci_pull_impl(rctx):
     ))
     rctx.file("oci-layout", json.encode_indent({"imageLayoutVersion": "1.0.0"}, indent = "    "))
 
+    tags = "[\"{}\"]".format("\", \"".join(rctx.attr.tags))
+
     rctx.file("BUILD.bazel", content = _BUILD_FILE_TMPL.format(
         target_name = rctx.attr.target_name,
+        tags = tags,
     ))
 
 oci_pull = repository_rule(

--- a/oci/pull.bzl
+++ b/oci/pull.bzl
@@ -103,7 +103,7 @@ _PLATFORM_TO_BAZEL_CPU = {
     "linux/mips64le": "@platforms//cpu:mips64",
 }
 
-def oci_pull(name, image = None, repository = None, registry = None, platforms = None, digest = None, tag = None, reproducible = True, is_bzlmod = False, config = None, config_path = None, import_tags = []):
+def oci_pull(name, image = None, repository = None, registry = None, platforms = None, digest = None, tag = None, reproducible = True, is_bzlmod = False, config = None, config_path = None, bazel_tags = []):
     """Repository macro to fetch image manifest data from a remote docker registry.
 
     To use the resulting image, you can use the `@wkspc` shorthand label, for example
@@ -138,7 +138,7 @@ def oci_pull(name, image = None, repository = None, registry = None, platforms =
         config: Label to a `.docker/config.json` file.
         config_path: Deprecated. use `config` attribute or DOCKER_CONFIG environment variable.
         is_bzlmod: whether the oci_pull is being called from a module extension
-        import_tags: Tags to be propagated to generated rules.
+        bazel_tags: Bazel tags to be propagated to generated rules.
     """
 
     # Check syntax sugar for registry/repository in place of image
@@ -184,7 +184,7 @@ def oci_pull(name, image = None, repository = None, registry = None, platforms =
                 config = config,
                 # TODO(2.0): remove
                 config_path = config_path,
-                tags = import_tags,
+                tags = bazel_tags,
             )
 
             if plat in _PLATFORM_TO_BAZEL_CPU:
@@ -209,7 +209,7 @@ def oci_pull(name, image = None, repository = None, registry = None, platforms =
             config = config,
             # TODO(2.0): remove
             config_path = config_path,
-            tags = import_tags,
+            tags = bazel_tags,
         )
 
     oci_alias(
@@ -228,5 +228,5 @@ def oci_pull(name, image = None, repository = None, registry = None, platforms =
         config = config,
         # TODO(2.0): remove
         config_path = config_path,
-        tags = import_tags,
+        tags = bazel_tags,
     )

--- a/oci/pull.bzl
+++ b/oci/pull.bzl
@@ -103,7 +103,7 @@ _PLATFORM_TO_BAZEL_CPU = {
     "linux/mips64le": "@platforms//cpu:mips64",
 }
 
-def oci_pull(name, image = None, repository = None, registry = None, platforms = None, digest = None, tag = None, reproducible = True, is_bzlmod = False, config = None, config_path = None):
+def oci_pull(name, image = None, repository = None, registry = None, platforms = None, digest = None, tag = None, reproducible = True, is_bzlmod = False, config = None, config_path = None, import_tags = []):
     """Repository macro to fetch image manifest data from a remote docker registry.
 
     To use the resulting image, you can use the `@wkspc` shorthand label, for example
@@ -138,6 +138,7 @@ def oci_pull(name, image = None, repository = None, registry = None, platforms =
         config: Label to a `.docker/config.json` file.
         config_path: Deprecated. use `config` attribute or DOCKER_CONFIG environment variable.
         is_bzlmod: whether the oci_pull is being called from a module extension
+        import_tags: Tags to be propagated to generated rules.
     """
 
     # Check syntax sugar for registry/repository in place of image
@@ -183,6 +184,7 @@ def oci_pull(name, image = None, repository = None, registry = None, platforms =
                 config = config,
                 # TODO(2.0): remove
                 config_path = config_path,
+                tags = import_tags,
             )
 
             if plat in _PLATFORM_TO_BAZEL_CPU:
@@ -207,6 +209,7 @@ def oci_pull(name, image = None, repository = None, registry = None, platforms =
             config = config,
             # TODO(2.0): remove
             config_path = config_path,
+            tags = import_tags,
         )
 
     oci_alias(
@@ -225,4 +228,5 @@ def oci_pull(name, image = None, repository = None, registry = None, platforms =
         config = config,
         # TODO(2.0): remove
         config_path = config_path,
+        tags = import_tags,
     )

--- a/oci/pull.bzl
+++ b/oci/pull.bzl
@@ -184,7 +184,7 @@ def oci_pull(name, image = None, repository = None, registry = None, platforms =
                 config = config,
                 # TODO(2.0): remove
                 config_path = config_path,
-                tags = bazel_tags,
+                bazel_tags = bazel_tags,
             )
 
             if plat in _PLATFORM_TO_BAZEL_CPU:
@@ -209,7 +209,7 @@ def oci_pull(name, image = None, repository = None, registry = None, platforms =
             config = config,
             # TODO(2.0): remove
             config_path = config_path,
-            tags = bazel_tags,
+            bazel_tags = bazel_tags,
         )
 
     oci_alias(
@@ -228,5 +228,4 @@ def oci_pull(name, image = None, repository = None, registry = None, platforms =
         config = config,
         # TODO(2.0): remove
         config_path = config_path,
-        tags = bazel_tags,
     )


### PR DESCRIPTION
Adds an import_tags attribute to the oci_pull macro to allow passing Bazel tags to the underlying rules. This implementation follows the naming and general implementation of the import_tags attribute on the old legacy container_pull rule.

#572 