### PR TITLE
Exclude the use of xattrs

### DIFF
--- a/oci/private/tarball.sh.tpl
+++ b/oci/private/tarball.sh.tpl
@@ -137,4 +137,4 @@ layers="${LAYERS}" \
         --output-format json > "${STAGING_DIR}/manifest.json"
 
 # TODO: https://github.com/bazel-contrib/rules_oci/issues/217
-tar -C "${STAGING_DIR}" -cf "${TARBALL_PATH}" manifest.json blobs
+tar -C --no-xattrs "${STAGING_DIR}" -cf "${TARBALL_PATH}" manifest.json blobs


### PR DESCRIPTION
Error was seen in multiple environments all Mac OS 14.3.1
lsetxattr com.apple.provenance /blobs/sha256/something.tar.gz: operation not supported

After making this change the issue is not observed.