### PR TITLE
fix: duplicate tar copying

### DIFF
--- a/examples/assertion/BUILD.bazel
+++ b/examples/assertion/BUILD.bazel
@@ -27,10 +27,22 @@ oci_image(
 )
 
 oci_image(
-    name = "same_tar_multiple_times_2",
+    name = "case2",
     base = ":same_tar_multiple_times",
     tars = [
         ":empty_tar",
+    ],
+)
+
+# Case 3: Adding an identical tar from another directory multiple times
+oci_image(
+    name = "case3",
+    architecture = "arm64",
+    os = "linux",
+    tars = [
+        # layer_0 and layer_1 is identical
+        "//examples/just_tar:layer_0",
+        "//examples/just_tar:layer_1",
     ],
 )
 
@@ -39,6 +51,7 @@ build_test(
     name = "test",
     targets = [
         ":imagE",
-        ":same_tar_multiple_times_2",
+        ":case2",
+        ":case3",
     ],
 )

--- a/examples/assertion/README.md
+++ b/examples/assertion/README.md
@@ -1,0 +1,1 @@
+This directory is not useful as an example, merely exists for test coverage.

--- a/examples/big_image/README.md
+++ b/examples/big_image/README.md
@@ -1,0 +1,1 @@
+This directory is not useful as an example, merely exists for test coverage.

--- a/examples/just_tar/BUILD.bazel
+++ b/examples/just_tar/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@aspect_bazel_lib//lib:tar.bzl", "tar")
+
+# See `Case 3` in examples/assertion
+genrule(
+    name = "10mb_file",
+    outs = ["10mb_file.out"],
+    cmd = "head -c 10485760 < /dev/urandom > $@",
+    local = True,
+    tags = ["manual"],
+)
+
+[
+    tar(
+        name = "layer_%s" % i,
+        srcs = ["10mb_file"],
+        tags = ["manual"],
+        visibility = ["//examples/assertion:__pkg__"],
+    )
+    for i in range(2)
+]

--- a/examples/just_tar/README.md
+++ b/examples/just_tar/README.md
@@ -1,0 +1,1 @@
+This directory is not useful as an example, merely exists for test coverage.

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -1,0 +1,1 @@
+This directory is not useful as an example, merely exists for test coverage.

--- a/examples/various/BUILD.bazel
+++ b/examples/various/BUILD.bazel
@@ -1,6 +1,8 @@
+load("@aspect_bazel_lib//lib:tar.bzl", "tar")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("//oci:defs.bzl", "oci_image")
 
+# Case 1: image name containing a capital case.
 oci_image(
     name = "imagE",
     architecture = "amd64",
@@ -8,9 +10,35 @@ oci_image(
     os = "linux",
 )
 
+# Case 2: existing layer added again.
+tar(
+    name = "empty_tar",
+    srcs = [],
+)
+
+oci_image(
+    name = "same_tar_multiple_times",
+    architecture = "amd64",
+    cmd = ["noop"],
+    os = "linux",
+    tars = [
+        ":empty_tar",
+    ],
+)
+
+oci_image(
+    name = "same_tar_multiple_times_2",
+    base = ":same_tar_multiple_times",
+    tars = [
+        ":empty_tar",
+    ],
+)
+
+# build them as test.
 build_test(
     name = "test",
     targets = [
         ":imagE",
+        ":same_tar_multiple_times_2",
     ],
 )

--- a/oci/private/image.sh
+++ b/oci/private/image.sh
@@ -106,11 +106,9 @@ function add_layer() {
   digest_path="$(jq -r '.digest | sub(":"; "/")' <<< "$desc")"
   output_path="$OUTPUT/blobs/$digest_path"
 
-  if [[ -e "$output_path" ]]; then
-    : # noop, blob exists already, whether symlink or regular file.
-  elif [[ "$USE_TREEARTIFACT_SYMLINKS" == "1" ]]; then
+  if [[ "$USE_TREEARTIFACT_SYMLINKS" == "1" ]]; then
     relative=$(coreutils realpath --no-symlinks --canonicalize-missing --relative-to="$OUTPUT/blobs/sha256" "$path" )
-    coreutils ln -s "$relative" "$output_path"
+    coreutils ln --force --symbolic "$relative" "$output_path"
   else
     coreutils cat "$path" > "$output_path"
   fi

--- a/oci/private/image.sh
+++ b/oci/private/image.sh
@@ -102,13 +102,17 @@ function add_layer() {
       --arg media_type "${media_type}" | update_manifest
 
   local digest_path= 
+  local output_path=
   digest_path="$(jq -r '.digest | sub(":"; "/")' <<< "$desc")"
+  output_path="$OUTPUT/blobs/$digest_path"
 
-  if [[ "$USE_TREEARTIFACT_SYMLINKS" == "1" ]]; then
+  if [[ -e "$output_path" ]]; then
+    : # noop, blob exists already, whether symlink or regular file.
+  elif [[ "$USE_TREEARTIFACT_SYMLINKS" == "1" ]]; then
     relative=$(coreutils realpath --no-symlinks --canonicalize-missing --relative-to="$OUTPUT/blobs/sha256" "$path" )
-    coreutils ln -s "$relative" "$OUTPUT/blobs/$digest_path"
+    coreutils ln -s "$relative" "$output_path"
   else
-    coreutils cat "$path" > "$OUTPUT/blobs/$digest_path"
+    coreutils cat "$path" > "$output_path"
   fi
 }
 

--- a/oci/private/push.bzl
+++ b/oci/private/push.bzl
@@ -186,7 +186,7 @@ oci_push_lib = struct(
     attrs = _attrs,
     toolchains = [
         "@rules_oci//oci:crane_toolchain_type",
-        "@aspect_bazel_lib//lib:yq_toolchain_type",
+        "@aspect_bazel_lib//lib:jq_toolchain_type",
         "@bazel_tools//tools/sh:toolchain_type",
     ],
 )


### PR DESCRIPTION
When a blob exists already, there's no reason to try to relink or copy it to the output folder.  See: https://github.com/bazel-contrib/rules_oci/issues/566#issuecomment-2106839723

fixes #566 