### PR TITLE
Quotes removal from MEDIA_TYPE string.

### DIFF
--- a/oci/private/tarball.sh.tpl
+++ b/oci/private/tarball.sh.tpl
@@ -25,7 +25,7 @@ if [[ "${MANIFESTS_LENGTH}" != 1 ]]; then
   exit 1
 fi
 
-MEDIA_TYPE=$("${YQ}" eval ".manifests[0].mediaType" "${INDEX_FILE}")
+MEDIA_TYPE=$("${YQ}" -r eval ".manifests[0].mediaType" "${INDEX_FILE}")
 
 # Check that we know how to generate the output format given the input format.
 # We may expand the supported options here in the future, but for now,

--- a/oci/private/tarball.sh.tpl
+++ b/oci/private/tarball.sh.tpl
@@ -25,7 +25,7 @@ if [[ "${MANIFESTS_LENGTH}" != 1 ]]; then
   exit 1
 fi
 
-MEDIA_TYPE=$("${YQ}" -r eval ".manifests[0].mediaType" "${INDEX_FILE}")
+MEDIA_TYPE=$("${YQ}" --unwrapScalar eval ".manifests[0].mediaType" "${INDEX_FILE}")
 
 # Check that we know how to generate the output format given the input format.
 # We may expand the supported options here in the future, but for now,


### PR DESCRIPTION
Hello,

I've noticed that in my case following build description:

```
oci_image(
    name = "img-amd64",
    base = "@eclipse_temurin_17_linux_amd64",
    tars = [
        ":app-tar"
    ],
)

oci_image(
    name = "img-arm64",
    base = "@eclipse_temurin_17_linux_arm64_v8",
    tars = [
        ":app-tar"
    ],
)

oci_image_index(
    name = "img-multiarch",
    images = [
        ":img-arm64",
        ":img-amd64"
    ]
)

oci_tarball(
    name = "img-tarball",
    format = "oci",
    image = ":img-multiarch",
    repo_tags = ["some-name:latest"],
)
```

was causing following error:
```
bazel run //:img-tarball
INFO: Invocation ID: 61c8d196-44e6-4e78-8d80-d2b9c23f29e0
INFO: Analyzed target //:img-tarball (33 packages loaded, 291 targets configured).
INFO: Found 1 target...
ERROR: BUILD.bazel:179:12: OCI Tarball //:img-tarball failed: (Exit 1): tarball.sh failed: error executing command (from target //:img-tarball) bazel-out/k8-fastbuild/bin/some-project/img-tarball/tarball.sh

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
Format oci is only supported for oci_image_index targets but saw "application/vnd.oci.image.index.v1+json"
Target //activity-sec:img-tarball failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 0.216s, Critical Path: 0.04s
INFO: 2 processes: 2 internal.
FAILED: Build did NOT complete successfully
```

Indeed, dropping the quotes from MEDIA_TYPE via `yq`'s `-r` option helped.

```
$ yq --help | grep quotes
  -r, --unwrapScalar                  unwrap scalar, print the value with no quotes, colors or comments. Defaults to true for yaml (default true)
```

Best regards,
Karol