### PR TITLE
Return extension_metadata from oci.pull()

### DIFF
--- a/oci/extensions.bzl
+++ b/oci/extensions.bzl
@@ -29,6 +29,8 @@ Overriding the default is only permitted in the root module.
 
 def _oci_extension(module_ctx):
     registrations = {}
+    root_direct_deps = []
+    root_direct_dev_deps = []
     for mod in module_ctx.modules:
         for pull in mod.tags.pull:
             oci_pull(
@@ -41,6 +43,11 @@ def _oci_extension(module_ctx):
                 config = pull.config,
                 is_bzlmod = True,
             )
+            if mod.is_root:
+                if module_ctx.is_dev_dependency(pull):
+                    root_direct_dev_deps.append(pull.name)
+                else:
+                    root_direct_deps.append(pull.name)
         for toolchains in mod.tags.toolchains:
             if toolchains.name != "oci" and not mod.is_root:
                 fail("""\
@@ -60,6 +67,11 @@ def _oci_extension(module_ctx):
         else:
             selected = versions[0]
         oci_register_toolchains(name, crane_version = selected[0], zot_version = selected[1], register = False)
+
+    return module_ctx.extension_metadata(
+        root_module_direct_deps = root_direct_deps,
+        root_module_direct_dev_deps = root_direct_dev_deps,
+    )
 
 oci = module_extension(
     implementation = _oci_extension,

--- a/oci/extensions.bzl
+++ b/oci/extensions.bzl
@@ -68,6 +68,8 @@ def _oci_extension(module_ctx):
             selected = versions[0]
         oci_register_toolchains(name, crane_version = selected[0], zot_version = selected[1], register = False)
 
+    # Allow use_repo calls to be automatically managed by `bazel mod tidy`. See
+    # https://docs.google.com/document/d/1dj8SN5L6nwhNOufNqjBhYkk5f-BJI_FPYWKxlB3GAmA/edit#heading=h.5mcn15i0e1ch
     return module_ctx.extension_metadata(
         root_module_direct_deps = root_direct_deps,
         root_module_direct_dev_deps = root_direct_dev_deps,


### PR DESCRIPTION
Return extension_metadata from oci.pull(), making `bazel mod tidy` automagically populate `use_repo(oci, ...)` in MODULE.bazel

Fixes https://github.com/bazel-contrib/rules_oci/issues/529