### PR TITLE
--unwrapScalar for yq cmd

### DIFF
--- a/oci/private/push.sh.tpl
+++ b/oci/private/push.sh.tpl
@@ -44,7 +44,7 @@ while (( $# > 0 )); do
   esac
 done
 
-DIGEST=$("${YQ}" eval '.manifests[0].digest' "${IMAGE_DIR}/index.json")
+DIGEST=$("${YQ}" --unwrapScalar eval '.manifests[0].digest' "${IMAGE_DIR}/index.json")
 
 REFS=$(mktemp)
 "${CRANE}" push "${IMAGE_DIR}" "${REPOSITORY}@${DIGEST}" "${ARGS[@]+"${ARGS[@]}"}" --image-refs "${REFS}"


### PR DESCRIPTION
Same as https://github.com/bazel-contrib/rules_oci/pull/577

Without this flag, I get the following error while running push target:
```
Error: could not parse reference: <redacted>@"sha256:64f4e09cc1516853175ec87b0fde29673b99864262a82bd0eac5b1faaa46ef3b"
```