### PR TITLE
Copy files using coreutils cp

### DIFF
--- a/oci/private/image.sh
+++ b/oci/private/image.sh
@@ -41,10 +41,10 @@ function base_from() {
       relative="$(coreutils realpath --relative-to="$OUTPUT/blobs/sha256" "$blob" --no-symlinks)"
       coreutils ln -s "$relative" "$OUTPUT/blobs/$relative_to_blobs"
     else
-      coreutils cat "$blob" > "$OUTPUT/blobs/$relative_to_blobs"
+      coreutils cp "$blob" "$OUTPUT/blobs/$relative_to_blobs"
     fi
   done
-  coreutils cat "$path/oci-layout" >"$OUTPUT/oci-layout"
+  coreutils cp "$path/oci-layout" "$OUTPUT/oci-layout"
   jq '.manifests[0].annotations["org.opencontainers.image.ref.name"] = "intermediate"' "$path/index.json" >"$OUTPUT/index.json"
 }
 
@@ -110,7 +110,7 @@ function add_layer() {
     relative=$(coreutils realpath --no-symlinks --canonicalize-missing --relative-to="$OUTPUT/blobs/sha256" "$path" )
     coreutils ln --force --symbolic "$relative" "$output_path"
   else
-    coreutils cat "$path" > "$output_path"
+    coreutils cp "$path" "$output_path"
   fi
 }
 

--- a/oci/private/image.sh
+++ b/oci/private/image.sh
@@ -44,7 +44,7 @@ function base_from() {
       coreutils cp "$blob" "$OUTPUT/blobs/$relative_to_blobs"
     fi
   done
-  coreutils cp "$path/oci-layout" "$OUTPUT/oci-layout"
+  coreutils cp --no-preserve=mode "$path/oci-layout" "$OUTPUT/oci-layout"
   jq '.manifests[0].annotations["org.opencontainers.image.ref.name"] = "intermediate"' "$path/index.json" >"$OUTPUT/index.json"
 }
 

--- a/oci/private/image.sh
+++ b/oci/private/image.sh
@@ -41,7 +41,7 @@ function base_from() {
       relative="$(coreutils realpath --relative-to="$OUTPUT/blobs/sha256" "$blob" --no-symlinks)"
       coreutils ln -s "$relative" "$OUTPUT/blobs/$relative_to_blobs"
     else
-      coreutils cp "$blob" "$OUTPUT/blobs/$relative_to_blobs"
+      coreutils cp --no-preserve=mode "$blob" "$OUTPUT/blobs/$relative_to_blobs"
     fi
   done
   coreutils cp --no-preserve=mode "$path/oci-layout" "$OUTPUT/oci-layout"
@@ -110,7 +110,7 @@ function add_layer() {
     relative=$(coreutils realpath --no-symlinks --canonicalize-missing --relative-to="$OUTPUT/blobs/sha256" "$path" )
     coreutils ln --force --symbolic "$relative" "$output_path"
   else
-    coreutils cp "$path" "$output_path"
+    coreutils cp --no-preserve=mode "$path" "$output_path"
   fi
 }
 

--- a/oci/private/image_index.sh.tpl
+++ b/oci/private/image_index.sh.tpl
@@ -26,7 +26,7 @@ function add_image() {
                 --argjson manifest "${manifest}" \
                 '.manifests |= [$manifest + {"platform": $platform}]'\
                 "${output_path}/manifest_list.json" > "${output_path}/manifest_list.new.json"
-        cat "${output_path}/manifest_list.new.json" > "${output_path}/manifest_list.json"
+        "${COREUTILS}" cp "${output_path}/manifest_list.new.json" "${output_path}/manifest_list.json"
     done
 }
 
@@ -36,7 +36,7 @@ function copy_blob() {
     local blob_image_relative_path="$3"
     local dest_path="${output_path}/${blob_image_relative_path}"
     mkdirp "$(dirname "${dest_path}")"
-    "${COREUTILS}" cat "${image_path}/${blob_image_relative_path}" > "${dest_path}"
+    "${COREUTILS}" cp "${image_path}/${blob_image_relative_path}" "${dest_path}"
 }
 
 function create_oci_layout() {

--- a/oci/private/image_index.sh.tpl
+++ b/oci/private/image_index.sh.tpl
@@ -26,7 +26,7 @@ function add_image() {
                 --argjson manifest "${manifest}" \
                 '.manifests |= [$manifest + {"platform": $platform}]'\
                 "${output_path}/manifest_list.json" > "${output_path}/manifest_list.new.json"
-        "${COREUTILS}" cp "${output_path}/manifest_list.new.json" "${output_path}/manifest_list.json"
+        "${COREUTILS}" cp --no-preserve=mode "${output_path}/manifest_list.new.json" "${output_path}/manifest_list.json"
     done
 }
 
@@ -36,7 +36,7 @@ function copy_blob() {
     local blob_image_relative_path="$3"
     local dest_path="${output_path}/${blob_image_relative_path}"
     mkdirp "$(dirname "${dest_path}")"
-    "${COREUTILS}" cp "${image_path}/${blob_image_relative_path}" "${dest_path}"
+    "${COREUTILS}" cp --no-preserve=mode "${image_path}/${blob_image_relative_path}" "${dest_path}"
 }
 
 function create_oci_layout() {


### PR DESCRIPTION
Unlike `cat` redirected to a file, `cp` sees both its input and output and can more readily know the details of its arguments. These details can sometimes be exploited to achieve zero-copy transfers when the OS and filesystem know how to do copy-on-write (e.g. `clonefile` on Mac, `copy_file_range` on Linux). uutils' `cp` will attempt to take advantage of these opportunities where possible (see: https://github.com/uutils/coreutils/blob/35232689366fb102854693b6bd6b6161901d192e/src/uu/cp/src/cp.rs#L2190 ).

We need to pass `--no-preserve=mode` in order for `cp` to create the files as writable; which is necessary as some of the copies we perform need to be mutated afterwards. Depending on the nature of the Bazel setup, action input files might be readable but not writable, so the default behaviour of `cp` to preserve the permissions from its input to its output in this case would cause our later mutations to fail.

Also convert one of the remaining references to the system's `cat` (rather than uutils') in order to also convert it to a call to `cp`.