### PR TITLE
Support passing headers to download if Bazel supports it

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,6 +7,7 @@ module(
 )
 
 bazel_dep(name = "aspect_bazel_lib", version = "1.42.1")
+bazel_dep(name = "bazel_features", version = "1.11.0")
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "platforms", version = "0.0.5")
 

--- a/oci/private/download.bzl
+++ b/oci/private/download.bzl
@@ -1,6 +1,7 @@
 "Downloader functions "
 
 load("@aspect_bazel_lib//lib:base64.bzl", "base64")
+load("@bazel_features//:features.bzl", "bazel_features")
 load("@bazel_skylib//lib:versions.bzl", "versions")
 load(":util.bzl", "util")
 
@@ -118,7 +119,10 @@ def _bazel_download(
         headers = {},
         # passthrough
         **kwargs):
-    return rctx.download(**kwargs)
+    if bazel_features.external_deps.download_has_headers_param:
+        return rctx.download(headers = headers, **kwargs)
+    else:
+        return rctx.download(**kwargs)
 
 download = struct(
     curl = _download,

--- a/oci/private/pull.bzl
+++ b/oci/private/pull.bzl
@@ -120,7 +120,12 @@ def _download_manifest(rctx, authn, identifier, output):
     manifest = None
     digest = None
 
-    result = _download(rctx, authn, identifier, output, "manifests", allow_fail = True)
+    headers = {
+        "Accept": ",".join(_SUPPORTED_MEDIA_TYPES["index"] + _SUPPORTED_MEDIA_TYPES["manifest"]),
+        "Docker-Distribution-API-Version": "registry/2.0",
+    }
+
+    result = _download(rctx, authn, identifier, output, "manifests", allow_fail = True, headers = headers)
 
     fallback_to_curl = False
     if result.success:
@@ -146,10 +151,7 @@ def _download_manifest(rctx, authn, identifier, output):
             output,
             "manifests",
             download.curl,
-            headers = {
-                "Accept": ",".join(_SUPPORTED_MEDIA_TYPES["index"] + _SUPPORTED_MEDIA_TYPES["manifest"]),
-                "Docker-Distribution-API-Version": "registry/2.0",
-            },
+            headers = headers,
         )
         bytes = rctx.read(output)
         manifest = json.decode(bytes)


### PR DESCRIPTION
Rather than falling back to curl let's actually pass the headers to the native Bazel downloader if we're running a version of Bazel that supports them (i.e. >= 7.1.0). I had to bring the `bazel_features` repo to detect this.

Note that I've kept support for curl rather than introducing the breaking change (as #562 discusses) so that we can start taking advantage of it without breaking for people still on older versions of Bazel.