### PR TITLE
fix: Support global credsStore in docker config

### DIFF
--- a/e2e/pull/test.bats
+++ b/e2e/pull/test.bats
@@ -91,6 +91,17 @@ EOF
     assert_success
 }
 
+@test "global credstore" {
+    cat > "$DOCKER_CONFIG/config.json" <<EOF
+{
+  "credsStore": "oci"
+}
+EOF
+    update_assert '{"Authorization": ["Basic dGVzdGluZzpvY2k="]}'
+    run bazel build @empty_image//... $BAZEL_FLAGS
+    assert_success
+}
+
 @test "credstore misbehaves" {
     cat > "$DOCKER_CONFIG/config.json" <<EOF
 {

--- a/oci/private/authn.bzl
+++ b/oci/private/authn.bzl
@@ -181,6 +181,10 @@ def _get_auth(rctx, state, registry):
                         "password": auth_val["password"],
                     }
 
+    # look for generic credentials-store all lookups for host-specific auth fails
+    if "credsStore" in config and len(pattern.keys()) == 0:
+        pattern = _fetch_auth_via_creds_helper(rctx, registry, config["credsStore"])
+
     # cache the result so that we don't do this again unnecessarily.
     state["auth"][registry] = pattern
 


### PR DESCRIPTION
It is perfectly normal to have config.json with just the global config store:

    { "credsStore": "osxkeychain" }

See https://github.com/docker/docker-credential-helpers?tab=readme-ov-file#usage and https://github.com/google/go-containerregistry/tree/main/pkg/authn#helpers for examples.

Previously, the authn-code would only look at the `credsStore` if there was a specific host maching in `auths`, but lacking other authn-fields.

Now it also looks at the global `credsStore` as a fallback.

Fixes #388.