### PR TITLE
chore: disable dockerfile example

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -155,12 +155,6 @@ jobs:
           )
           EOF
 
-      # the /examples/dockerfile uses buildx to build Dockerfile images which needs to use a docker-container
-      # builder to work, which does not exist by default. Create one here.
-      - name: Setup buildx
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: bazel run examples/dockerfile:buildx -- create --name container --driver=docker-container
-
       - name: bazel test //...
         working-directory: ${{ matrix.folder }}
         env:

--- a/examples/dockerfile/BUILD.bazel
+++ b/examples/dockerfile/BUILD.bazel
@@ -26,6 +26,7 @@ run_binary(
     ],
     execution_requirements = {"local": "1"},
     out_dirs = ["base"],
+    tags = ["manual"],
     target_compatible_with = [
         "@platforms//os:linux",
     ],
@@ -35,16 +36,19 @@ run_binary(
 oci_image(
     name = "image",
     base = ":base",
+    tags = ["manual"],
 )
 
 oci_tarball(
     name = "tar",
     image = ":image",
     repo_tags = [],
+    tags = ["manual"],
 )
 
 container_structure_test(
     name = "test",
     configs = ["test.yaml"],
     image = ":image",
+    tags = ["manual"],
 )


### PR DESCRIPTION
This example required a bit of preconfiguration in CI settings, but the release pipeline uses a composite ruleset from bazel-contrib so we can't change it.  Disabling the examples/dockerfile for now.