### PR TITLE
Fix `jq: error (at <stdin>:16): Cannot use null (null) as object key` error on empty line in labels file

### DIFF
--- a/oci/private/image.sh
+++ b/oci/private/image.sh
@@ -159,7 +159,7 @@ for ARG in "$@"; do
     CONFIG=$(jq --arg workdir "${ARG#--workdir=}" '.config.WorkingDir = $workdir' <<<"$CONFIG")
     ;;
   --labels=*)
-    CONFIG=$(jq --rawfile labels "${ARG#--labels=}" '.config.Labels += ($labels | split("\n") | map(. | split("=")) | map({key: .[0], value: .[1:] | join("=")}) | from_entries)' <<<"$CONFIG")
+    CONFIG=$(jq --rawfile labels "${ARG#--labels=}" '.config.Labels += ($labels | split("\n") | map(select(. | length > 0)) | map(. | split("=")) | map({key: .[0], value: .[1:] | join("=")}) | from_entries)' <<<"$CONFIG")
     ;;
   --annotations=*)
     get_manifest |


### PR DESCRIPTION
This error also occurs when a file with labels ends with an EOL character.

Fix #613