### PR TITLE
fix: make oci_tarball work with disjoint output root

### DIFF
--- a/examples/assertion/BUILD.bazel
+++ b/examples/assertion/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@aspect_bazel_lib//lib:tar.bzl", "tar")
+load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
-load("//oci:defs.bzl", "oci_image")
+load("//oci:defs.bzl", "oci_image", "oci_tarball")
 
 # Case 1: image name containing a capital case.
 oci_image(
@@ -46,6 +47,52 @@ oci_image(
     ],
 )
 
+# Case 4: Transition an oci_image and feed to oci_tarball
+oci_image(
+    name = "case4",
+    architecture = "arm64",
+    os = "linux",
+)
+
+platform_transition_filegroup(
+    name = "case4_transition",
+    srcs = [":case4"],
+    target_platform = "//examples:linux_arm64",
+)
+
+oci_tarball(
+    name = "case4_tarball",
+    image = ":case4_transition",
+    repo_tags = ["case4:example"],
+)
+
+filegroup(
+    name = "case4_tarball_tar",
+    srcs = [":case4_tarball"],
+    output_group = "tarball",
+)
+
+# Case 5:
+
+# Case 4: An oci_image directly fed into oci_tarball
+oci_image(
+    name = "case5",
+    architecture = "arm64",
+    os = "linux",
+)
+
+oci_tarball(
+    name = "case5_tarball",
+    image = ":case5",
+    repo_tags = ["case5:example"],
+)
+
+filegroup(
+    name = "case5_tarball_tar",
+    srcs = [":case5_tarball"],
+    output_group = "tarball",
+)
+
 # build them as test.
 build_test(
     name = "test",
@@ -53,5 +100,7 @@ build_test(
         ":imagE",
         ":case2",
         ":case3",
+        ":case4_tarball_tar",
+        ":case5_tarball_tar",
     ],
 )

--- a/oci/private/tarball.bzl
+++ b/oci/private/tarball.bzl
@@ -113,7 +113,6 @@ def _tarball_impl(ctx):
         "{{jq_path}}": jq.bin.path,
         "{{tar}}": bsdtar.tarinfo.binary.path,
         "{{image_dir}}": image.path,
-        "{{bindir}}": ctx.bin_dir.path,
         "{{output}}": mtree_spec.path,
         "{{json_out}}": image_json.path,
     }
@@ -148,7 +147,7 @@ def _tarball_impl(ctx):
         output = exe,
         substitutions = {
             "{{TAR}}": bsdtar.tarinfo.binary.short_path,
-            "{{mtree_path}}": mtree_spec.short_path,
+            "{{mtree_path}}": mtree_spec.path,
             "{{loader}}": ctx.file.loader.path if ctx.file.loader else "",
         },
         is_executable = True,
@@ -160,10 +159,8 @@ def _tarball_impl(ctx):
     tar_inputs = depset(direct = mtree_outputs, transitive = [mtree_inputs])
     tar_args = ctx.actions.args()
     tar_args.add_all(["--create", "--no-xattr", "--no-mac-metadata"])
-    tar_args.add_all(["--cd", ctx.bin_dir.path])
     tar_args.add("--file", tarball)
-    # To reference our mtree spec file, we have to undo the --cd by removing three path segments
-    tar_args.add(mtree_spec, format = "@../../../%s")
+    tar_args.add(mtree_spec, format = "@%s")
     ctx.actions.run(
         executable = bsdtar.tarinfo.binary,
         inputs = tar_inputs,

--- a/oci/private/tarball.sh.tpl
+++ b/oci/private/tarball.sh.tpl
@@ -17,7 +17,7 @@ readonly OUTPUT="{{output}}"
 function add_to_tar() {
     content=$1
     tar_path=$2
-    echo >>"${OUTPUT}" "${tar_path} uid=0 gid=0 mode=0755 time=1672560000 type=file content=${content#{{bindir}}/}"
+    echo >>"${OUTPUT}" "${tar_path} uid=0 gid=0 mode=0755 time=1672560000 type=file content=${content}"
 }
 
 MANIFEST_DIGEST=$(${JQ} -r '.manifests[0].digest | sub(":"; "/")' "${INDEX_FILE}" | tr  -d '"')

--- a/oci/private/tarball_run.sh.tpl
+++ b/oci/private/tarball_run.sh.tpl
@@ -13,6 +13,31 @@ else
     exit 1
 fi
 
+
+# The execroot detection code is copied from https://github.com/aspect-build/rules_js/blob/d4ac7025a83192d011b7dd7447975a538e34c49b/js/private/js_binary.sh.tpl#L169-L217
+if [[ "$PWD" == *"/bazel-out/"* ]]; then
+    bazel_out_segment="/bazel-out/"
+elif [[ "$PWD" == *"/BAZEL-~1/"* ]]; then
+    bazel_out_segment="/BAZEL-~1/"
+elif [[ "$PWD" == *"/bazel-~1/"* ]]; then
+    bazel_out_segment="/bazel-~1/"
+fi
+
+if [[ "${bazel_out_segment:-}" ]]; then
+    # We are in runfiles and we don't yet know the execroot
+    rest="${PWD#*"$bazel_out_segment"}"
+    index=$((${#PWD} - ${#rest} - ${#bazel_out_segment}))
+    if [ ${index} -lt 0 ]; then
+        echo "No 'bazel-out' folder found in path '${PWD}'" >&2
+        exit 1
+    fi
+    EXECROOT="${PWD:0:$index}"
+else
+    # We are in execroot or in some other context all or a manually run oci_tarball.
+    EXECROOT="${PWD}"
+fi
+
+
 "$CONTAINER_CLI" load --input <(
-    {{TAR}} --create --no-xattr --no-mac-metadata @"{{mtree_path}}"
+    {{TAR}} --cd "$EXECROOT" --create --no-xattr --no-mac-metadata @"{{mtree_path}}"
 )


### PR DESCRIPTION
A while back we changed oci_tarball for performance reasons, and we introduced two different ways to load tarball into the daemon, one where one run `bazel run :tarball_target` or `bazel build :tarball_target --output_groups=tarball && docker load -i tarball.path` or directly get the output in DAG. 

So in order to support all these cases we introduced some hacks like using `--cd` option to cd back into the execroot and strip the paths using `<ctx.bin_dir.path>`. 

Unfortunately this did not work for cases where bindir of oci_tarball and oci_image is disjoint, eg oci_image is transitioned but oci_tarball isn't simply because the assumption that everything is in the same `bazel-bin/cfg/bin` did not hold true in cases above. 

This PR fixes it by making eveything relative to execroot, which the case for action version by default, by introducing some execroot detection code copied from rules_js.