### PR TITLE
    fix: env vars containing =

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -15,3 +15,27 @@ platform(
         "@platforms//cpu:x86_64",
     ],
 )
+
+config_setting(
+    name = "platform_darwin_arm64",
+    constraint_values = [
+        "@platforms//os:macos",
+        "@platforms//cpu:arm64",
+    ],
+)
+
+config_setting(
+    name = "platform_darwin_amd64",
+    constraint_values = [
+        "@platforms//os:macos",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+config_setting(
+    name = "platform_linux_amd64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+)

--- a/examples/assertion/BUILD.bazel
+++ b/examples/assertion/BUILD.bazel
@@ -2,6 +2,7 @@ load("@aspect_bazel_lib//lib:tar.bzl", "tar")
 load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("//oci:defs.bzl", "oci_image", "oci_tarball")
+load(":assert.bzl", "assert_oci_config")
 
 # Case 1: image name containing a capital case.
 oci_image(
@@ -72,9 +73,7 @@ filegroup(
     output_group = "tarball",
 )
 
-# Case 5:
-
-# Case 4: An oci_image directly fed into oci_tarball
+# Case 5: An oci_image directly fed into oci_tarball
 oci_image(
     name = "case5",
     architecture = "arm64",
@@ -91,6 +90,40 @@ filegroup(
     name = "case5_tarball_tar",
     srcs = [":case5_tarball"],
     output_group = "tarball",
+)
+
+# Case 6: test all cases that might break
+oci_image(
+    name = "case6",
+    architecture = "arm64",
+    env = {
+        "TEST": "VALUE=",
+        "TEST2": "=VALUE=",
+        "TEST3": "=VALUE",
+        "TEST4": "=V=VALUE",
+        # an env that includes previously set $TEST env with a leading `=`
+        "LEAD_WITH_REF": "=$TEST",
+        "JUST_EQUALS": "======$$$$",
+        "1": "VAL",
+        # referencing non-existent env vars is just empty string.
+        "REFS": "$1:${1}:${NONEXISTENT}",
+    },
+    os = "linux",
+)
+
+assert_oci_config(
+    name = "test_case6",
+    env_eq = {
+        "TEST": "VALUE=",
+        "TEST2": "=VALUE=",
+        "TEST3": "=VALUE",
+        "TEST4": "=V=VALUE",
+        "LEAD_WITH_REF": "=VALUE=",
+        "JUST_EQUALS": "======$$$$",
+        "1": "VAL",
+        "REFS": "VAL:VAL:",
+    },
+    image = ":case6",
 )
 
 # build them as test.

--- a/examples/assertion/assert.bzl
+++ b/examples/assertion/assert.bzl
@@ -1,0 +1,100 @@
+"assertion rules to test metadata"
+
+load("@bazel_skylib//rules:native_binary.bzl", "native_test")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+
+DIGEST_CMD = """
+image_path="$(location {image})"
+manifest_digest=$$($(JQ_BIN) -r '.manifests[0].digest | sub(":"; "/")' $$image_path/index.json)
+config_digest=$$($(JQ_BIN) -r '.config.digest | sub(":"; "/")' $$image_path/blobs/$$manifest_digest)
+
+$(JQ_BIN) 'def pick(p): . as $$v | reduce path(p) as $$p ({{}}; setpath($$p; $$v | getpath($$p))); pick({keys})' "$$image_path/blobs/$$config_digest" > $@
+"""
+
+# buildifier: disable=function-docstring-args
+def assert_oci_config(
+        name,
+        image,
+        entrypoint_eq = None,
+        cmd_eq = None,
+        env_eq = None,
+        ports_eq = None,
+        user_eq = None,
+        workdir_eq = None,
+        architecture_eq = None,
+        os_eq = None,
+        variant_eq = None,
+        labels_eq = None):
+    "assert that an oci_image has specified config metadata according to https://github.com/opencontainers/image-spec/blob/main/config.md"
+    pick = []
+
+    config = {}
+
+    # .config
+    if entrypoint_eq:
+        config["Entrypoint"] = entrypoint_eq
+    if cmd_eq:
+        config["Cmd"] = cmd_eq
+    if env_eq:
+        config["Env"] = ["=".join(e) for e in env_eq.items()]
+    if workdir_eq:
+        config["Workdir"] = workdir_eq
+    if ports_eq:
+        config["Ports"] = ports_eq
+    if user_eq:
+        config["User"] = user_eq
+    if labels_eq:
+        config["Labels"] = labels_eq
+
+    pick = [".config." + k for k in config.keys()]
+
+    # .
+    config_json = {}
+
+    if os_eq:
+        config_json["os"] = os_eq
+    if architecture_eq:
+        config_json["architecture"] = architecture_eq
+    if variant_eq:
+        config_json["variant"] = variant_eq
+
+    pick += ["." + k for k in config_json.keys()]
+
+    if len(config.keys()):
+        config_json["config"] = config
+
+    expected = name + "_json"
+    write_file(
+        name = expected,
+        out = name + ".json",
+        content = [
+            json.encode_indent(config_json),
+        ],
+    )
+
+    actual = name + "_config_json"
+    native.genrule(
+        name = actual,
+        srcs = [image],
+        outs = [name + ".config.json"],
+        cmd = DIGEST_CMD.format(keys = ",".join(pick), image = image),
+        toolchains = ["@jq_toolchains//:resolved_toolchain"],
+    )
+
+    native_test(
+        name = name,
+        data = [
+            expected,
+            actual,
+        ],
+        args = [
+            "$(location %s)" % expected,
+            "$(location %s)" % actual,
+        ],
+        src = select({
+            "//examples:platform_darwin_arm64": "@jd_darwin_arm64//file",
+            "//examples:platform_linux_amd64": "@jd_linux_amd64//file",
+            "//examples:platform_darwin_amd64": "@jd_darwin_amd64//file",
+        }),
+        out = name,
+    )

--- a/fetch.bzl
+++ b/fetch.bzl
@@ -4,7 +4,7 @@ This file is similar to how bazel_gazelle can manage go_repository calls
 by writing them to a generated macro in a .bzl file.
 """
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 load("@rules_oci//oci:pull.bzl", "oci_pull")
 
 def fetch_images():
@@ -221,4 +221,31 @@ genrule(
             "http://ftp.us.debian.org/debian/pool/main/b/bash/bash_5.1-2+deb11u1_arm64.deb",
         ],
         sha256 = "d7c7af5d86f43a885069408a89788f67f248e8124c682bb73936f33874e0611b",
+    )
+
+    http_file(
+        name = "jd_darwin_arm64",
+        urls = [
+            "https://github.com/josephburnett/jd/releases/download/v1.8.1/jd-arm64-darwin",
+        ],
+        sha256 = "8b0e51b902650287b7dedc2beee476b96c5d589309d3a7f556334c1baedbec61",
+        executable = True,
+    )
+
+    http_file(
+        name = "jd_darwin_amd64",
+        urls = [
+            "https://github.com/josephburnett/jd/releases/download/v1.8.1/jd-amd64-darwin",
+        ],
+        sha256 = "c5fb5503d2804b1bf631bf12616d56b89711fd451ab233b688ca922402ff3444",
+        executable = True,
+    )
+
+    http_file(
+        name = "jd_linux_amd64",
+        urls = [
+            "https://github.com/josephburnett/jd/releases/download/v1.8.1/jd-amd64-linux",
+        ],
+        sha256 = "ab918f52130561abd4f88d9c2d3ae95d4d56f1a2dff9762665890349d61c763e",
+        executable = True,
     )

--- a/oci/private/image.sh
+++ b/oci/private/image.sh
@@ -131,9 +131,11 @@ for ARG in "$@"; do
   --env=*)
     # Get environment from existing config
     env=$(get_config | jq '(.config.Env // []) | map(. | split("=") | {"key": .[0], "value": .[1:] | join("=")})')
-
     while IFS= read -r expansion || [ -n "$expansion" ]; do
-      IFS="=" read -r key value <<<"${expansion}"
+      # collect all characters until a `=` is encountered
+      key="${expansion%%=*}"
+      # skip `length(k) + 1` to collect the rest.
+      value="${expansion:${#key}+1}"
       value_from_base=$(jq -nr --arg raw "${value}" --argjson envs "${env}" "${ENV_EXPAND_FILTER}")
       env=$(
         # update the existing env if it exists, or append to the end of env array.


### PR DESCRIPTION
This fixes a bug where oci_image removed the content of env variables after first `=` in the value.  This fixes that issue and adds more tests to test against other cases. 

I added a nice assertion rule similar to `assert_tar_contains` which doesn't depend on a docker daemon and doesn't require a yaml file as a configuration language.

(it was already somewhere in a branch, i just added it here so i can use it in the future.)

