### PR TITLE
nixos action_env

### DIFF
--- a/oci/private/image.bzl
+++ b/oci/private/image.bzl
@@ -188,6 +188,7 @@ def _oci_image_impl(ctx):
         executable = util.maybe_wrap_launcher_for_windows(ctx, builder),
         tools = [crane.crane_info.binary, registry.registry_info.launcher, registry.registry_info.registry, jq.jqinfo.bin],
         mnemonic = "OCIImage",
+        use_default_shell_env = True,
         progress_message = "OCI Image %{label}",
     )
 

--- a/oci/private/image_index.bzl
+++ b/oci/private/image_index.bzl
@@ -65,6 +65,7 @@ def _oci_image_index_impl(ctx):
         arguments = [args],
         outputs = [output],
         executable = launcher,
+        use_default_shell_env = True,
         tools = [yq.yqinfo.bin, coreutils.coreutils_info.bin],
         mnemonic = "OCIIndex",
         progress_message = "OCI Index %{label}",

--- a/oci/private/tarball.bzl
+++ b/oci/private/tarball.bzl
@@ -101,6 +101,7 @@ def _tarball_impl(ctx):
         outputs = [tarball],
         tools = [yq_bin],
         mnemonic = "OCITarball",
+        use_default_shell_env = True,
         progress_message = "OCI Tarball %{label}",
     )
 


### PR DESCRIPTION
In some systems (nixos), action_envs are used to tell the sandbox environment where to find basic system libraries. With this change, the user replace for instance:

```
test          --test_env=NIX_LD=/run/current-system/sw/share/nix-ld/lib/ld.so        --test_env=NIX_LD_LIBRARY_PATH=/run/current-system/sw/share/nix-ld/lib
common      --action_env=NIX_LD=/run/current-system/sw/share/nix-ld/lib/ld.so      --action_env=NIX_LD_LIBRARY_PATH=/run/current-system/sw/share/nix-ld/lib
common --host_action_env=NIX_LD=/run/current-system/sw/share/nix-ld/lib/ld.so --host_action_env=NIX_LD_LIBRARY_PATH=/run/current-system/sw/share/nix-ld/lib
```