### PR TITLE
fix: Ignore empty annotations in the jq query

### DIFF
--- a/oci/private/image.sh
+++ b/oci/private/image.sh
@@ -166,7 +166,7 @@ for ARG in "$@"; do
   --annotations=*)
     get_manifest |
       jq --rawfile annotations "${ARG#--annotations=}" \
-        '.annotations += ($annotations | split("\n") | map(. | split("=")) | map({key: .[0], value: .[1:] | join("=")}) | from_entries)' |
+      '.annotations += ([($annotations | split("\n") | .[] | select(. != ""))] | map(. | split("=")) | map({key: .[0], value: .[1:] | join("=")}) | from_entries)' |
       update_manifest
     ;;
   *)


### PR DESCRIPTION
When building OCI images, we use a newline separated file in the form "a=b\nb=c\nd=e". However, if this file has a trailing newline, you get a pretty confusing error like "jq: error (at <stdin>:37): Cannot use null (null) as object key" because jq splits that final newline into an empty string, and further tries to split it on the "=" which results in a null key.

Instead, filter out any empty strings.