### PR TITLE
Oauth2 support without Python

### DIFF
--- a/oci/private/authn.bzl
+++ b/oci/private/authn.bzl
@@ -2,7 +2,6 @@
 
 load("@aspect_bazel_lib//lib:base64.bzl", "base64")
 load("@aspect_bazel_lib//lib:repo_utils.bzl", "repo_utils")
-load("@bazel_skylib//lib:versions.bzl", "versions")
 load(":util.bzl", "util")
 
 
@@ -285,12 +284,8 @@ def _get_token(rctx, state, registry, repository):
 
             auth = None
             if pattern["login"] == "<token>":
-                if versions.is_at_least("7.0.0", versions.get() or "0.0.0"):
-                    if not rctx.getenv("OCI_ENABLE_OAUTH2_SUPPORT"):
-                        fail(IDENTITY_TOKEN_WARNING)
-                else:
-                    if not rctx.os.environ.get("OCI_ENABLE_OAUTH2_SUPPORT"):
-                        fail(IDENTITY_TOKEN_WARNING)
+                if not rctx.os.environ.get("OCI_ENABLE_OAUTH2_SUPPORT"):
+                    fail(IDENTITY_TOKEN_WARNING)
 
                 response = _oauth2(
                     rctx = rctx,
@@ -369,5 +364,6 @@ authn = struct(
         "REGISTRY_AUTH_FILE",
         "XDG_RUNTIME_DIR",
         "HOME",
+        "OCI_ENABLE_OAUTH2_SUPPORT",
     ]
 )

--- a/oci/private/authn.bzl
+++ b/oci/private/authn.bzl
@@ -285,7 +285,7 @@ def _get_token(rctx, state, registry, repository):
                 return state["token"][url]
 
             auth = None
-            if pattern["login"] == "<token>":
+            if pattern.get("login", None) == "<token>":
                 if not rctx.os.environ.get("OCI_ENABLE_OAUTH2_SUPPORT"):
                     fail(IDENTITY_TOKEN_WARNING)
 

--- a/oci/private/authn.bzl
+++ b/oci/private/authn.bzl
@@ -239,6 +239,8 @@ def _get_auth(rctx, state, registry):
                     login, sep, password = base64.decode(raw_auth).partition(":")
                     if not sep:
                         fail("auth string must be in form username:password")
+                    if not password and "identitytoken" in auth_val:
+                        password = auth_val["identitytoken"]
                     pattern = {
                         "type": "basic",
                         "login": login,

--- a/oci/private/authn.bzl
+++ b/oci/private/authn.bzl
@@ -2,6 +2,7 @@
 
 load("@aspect_bazel_lib//lib:base64.bzl", "base64")
 load("@aspect_bazel_lib//lib:repo_utils.bzl", "repo_utils")
+load("@bazel_skylib//lib:versions.bzl", "versions")
 load(":util.bzl", "util")
 
 
@@ -284,8 +285,12 @@ def _get_token(rctx, state, registry, repository):
 
             auth = None
             if pattern["login"] == "<token>":
-                if not rctx.getenv("OCI_ENABLE_OAUTH2_SUPPORT"):
-                    fail(IDENTITY_TOKEN_WARNING)
+                if versions.is_at_least("7.0.0", versions.get() or "0.0.0"):
+                    if not rctx.getenv("OCI_ENABLE_OAUTH2_SUPPORT"):
+                        fail(IDENTITY_TOKEN_WARNING)
+                else:
+                    if not rctx.os.environ.get("OCI_ENABLE_OAUTH2_SUPPORT"):
+                        fail(IDENTITY_TOKEN_WARNING)
 
                 response = _oauth2(
                     rctx = rctx,

--- a/oci/private/authn.bzl
+++ b/oci/private/authn.bzl
@@ -164,7 +164,6 @@ refresh_token=$4
 response=$(curl --silent --show-error --fail --request POST --data "grant_type=refresh_token&service=$service&scope=$scope&refresh_token=$refresh_token" $url)
 
 if [ $? -ne 0 ]; then
-    echo "oauth2 failed: curl request failed" >&2
     exit 1
 fi
 
@@ -180,7 +179,6 @@ refresh_token=$4
 response=$(wget --quiet --output-document=- --post-data "grant_type=refresh_token&service=$service&scope=$scope&refresh_token=$refresh_token" $url)
 
 if [ $? -ne 0 ]; then
-    echo "oauth2 failed: wget request failed" >&2
     exit 1
 fi
 
@@ -204,7 +202,7 @@ def _oauth2(rctx, realm, scope, service, secret):
         fail("oauth2 failed, could not find either of: curl, wget, powershell")
 
     if result.return_code:
-        fail("oauth2 failed: \nSTDOUT:\n{}\nSTDERR:\n{}".format(result.stdout, result.stderr))
+        fail("oauth2 failed:\nSTDOUT:\n{}\nSTDERR:\n{}".format(result.stdout, result.stderr))
     return result.stdout
 
 def _get_auth(rctx, state, registry):

--- a/oci/private/util.bzl
+++ b/oci/private/util.bzl
@@ -171,7 +171,10 @@ if defined args (
     return win_launcher
 
 def _file_exists(rctx, path):
-    result = rctx.execute(["stat", path])
+    if rctx.os.name.startswith("windows"):
+        result = rctx.execute(["cmd", "/c", "if exist {0} (exit 0) else (exit 1)".format(path)])
+    else:
+        result = rctx.execute(["stat", path])
     return result.return_code == 0
 
 _INDEX_JSON_TMPL="""\

--- a/oci/private/util.bzl
+++ b/oci/private/util.bzl
@@ -171,10 +171,7 @@ if defined args (
     return win_launcher
 
 def _file_exists(rctx, path):
-    if rctx.os.name.startswith("windows"):
-        result = rctx.execute(["cmd", "/c", "if exist {0} (exit 0) else (exit 1)".format(path)])
-    else:
-        result = rctx.execute(["stat", path])
+    result = rctx.execute(["stat", path])
     return result.return_code == 0
 
 _INDEX_JSON_TMPL="""\


### PR DESCRIPTION
Due to inactivity, I picked up this PR: https://github.com/bazel-contrib/rules_oci/pull/581

I implememented the mentioned workarounds, i.e. in case of windows, I try to run script using powershell, otherwise, I fallback to curl and then wget, both wrapped in a bash script.

I tested these with an azure repo which requires oauth2. I also tested it on windows. I found that the config.json is not found due to "stat" binary not existing on windows, so I fixed this too.