### PR TITLE
fix: accumulate image manifests in oci_image_index

### DIFF
--- a/examples/multi_architecture_image/BUILD.bazel
+++ b/examples/multi_architecture_image/BUILD.bazel
@@ -43,5 +43,5 @@ genrule(
 assert_contains(
     name = "check_digest",
     actual = ":hash",
-    expected = "sha256:9163db354e086c5ef0170ce0ec318312dde887f660552c4a438926863d473d3c",
+    expected = "sha256:9cc41e3583d5385aa6adc686c15f4e4625ec46fceabde54146add048aa95e716",
 )

--- a/oci/private/image_index.sh.tpl
+++ b/oci/private/image_index.sh.tpl
@@ -24,7 +24,7 @@ function add_image() {
         local platform=$("${JQ}" -c '{"os": .os, "architecture": .architecture, "variant": .variant, "os.version": .["os.version"], "os.features": .["os.features"]} | with_entries(select( .value != null ))' "${image_path}/blobs/${config_blob_path}")
         "${JQ}" --argjson platform "${platform}" \
                 --argjson manifest "${manifest}" \
-                '.manifests |= [$manifest + {"platform": $platform}]'\
+                '.manifests += [$manifest + {"platform": $platform}]'\
                 "${output_path}/manifest_list.json" > "${output_path}/manifest_list.new.json"
         "${COREUTILS}" cp --no-preserve=mode "${output_path}/manifest_list.new.json" "${output_path}/manifest_list.json"
     done


### PR DESCRIPTION
In the recent bazel-contrib/rules_oci#386, when we replaced use of the _yq_ tool with the _jq_ tool, we [translated the `oci_image_index` rule's accumulation of image manifests incorrectly](https://github.com/bazel-contrib/rules_oci/pull/386/files#r1646778569), such that we lose all but the last index that we add to the index.

In `jq`, [the _update-assignment_ operator](https://jqlang.github.io/jq/manual/#update-assignment) (`|=`) does not append to an array supplied as its left-hand context value automatically. Instead, one must use [a _complex assignment_](https://jqlang.github.io/jq/manual/#complex-assignments), mentioning the context value explicitly together with [the addition operator](https://jqlang.github.io/jq/manual/#addition).

See [the preceding discussion in the "docker" channel](https://bazelbuild.slack.com/archives/CA3NW13MH/p1718836203461049) of the "Bazel" Slack workspace a chronicle of discovering this defect.

Fixes #638.