### PR TITLE
fix oci image index script

### DIFF
--- a/oci/private/image_index.sh.tpl
+++ b/oci/private/image_index.sh.tpl
@@ -24,7 +24,7 @@ function add_image() {
         local platform=$("${JQ}" -c '{"os": .os, "architecture": .architecture, "variant": .variant, "os.version": .["os.version"], "os.features": .["os.features"]} | with_entries(select( .value != null ))' "${image_path}/blobs/${config_blob_path}")
         "${JQ}" --argjson platform "${platform}" \
                 --argjson manifest "${manifest}" \
-                '.manifests |= [$manifest + {"platform": $platform}]'\
+                '.manifests += [$manifest + {"platform": $platform}]'\
                 "${output_path}/manifest_list.json" > "${output_path}/manifest_list.new.json"
         "${COREUTILS}" cp --no-preserve=mode "${output_path}/manifest_list.new.json" "${output_path}/manifest_list.json"
     done


### PR DESCRIPTION
The script does not work for multiarch images as it does not append to the manifests. Instead it replaces with the latest one which results in the last architecture to be the only one supported. JQ has an option to append an element to an array.

Fixes #638