### PR TITLE
fix: propagate transitive inputs

### DIFF
--- a/cosign/private/attest.bzl
+++ b/cosign/private/attest.bzl
@@ -75,6 +75,7 @@ def _cosign_attest_impl(ctx):
     )
 
     runfiles = ctx.runfiles(files = [ctx.file.image, ctx.file.predicate])
+    runfiles = runfiles.merge(ctx.attr.image[DefaultInfo].default_runfiles)
     runfiles = runfiles.merge(jq.default.default_runfiles)
     runfiles = runfiles.merge(cosign.default.default_runfiles)
 

--- a/cosign/private/sign.bzl
+++ b/cosign/private/sign.bzl
@@ -63,6 +63,7 @@ def _cosign_sign_impl(ctx):
     )
 
     runfiles = ctx.runfiles(files = [ctx.file.image])
+    runfiles = runfiles.merge(ctx.attr.image[DefaultInfo].default_runfiles)
     runfiles = runfiles.merge(jq.default.default_runfiles)
     runfiles = runfiles.merge(cosign.default.default_runfiles)
 

--- a/examples/assertion/BUILD.bazel
+++ b/examples/assertion/BUILD.bazel
@@ -348,6 +348,43 @@ sh_test(
     data = [":case11_tarball"],
 )
 
+# Case 12: oci_push an image that has transitive deps
+tar(
+    name = "case12_empty_dir",
+    mtree = [
+        "./empty type=dir",
+    ],
+)
+
+oci_image(
+    name = "case12_base",
+    architecture = "arm64",
+    os = "linux",
+    tars = [":case12_empty_dir"],
+)
+
+tar(
+    name = "case12_empty_dir2",
+    mtree = [
+        "./empty2 type=dir",
+    ],
+)
+
+oci_image(
+    name = "case12",
+    base = ":case12_base",
+    tars = [":case12_empty_dir2"],
+)
+
+sh_test(
+    name = "case12_test",
+    srcs = ["assert_push_transitive_deps.sh"],
+    args = [
+        "$(location :case12)",
+    ],
+    data = [":case12"],
+)
+
 # build them as test.
 build_test(
     name = "test",

--- a/examples/assertion/assert_push_transitive_deps.sh
+++ b/examples/assertion/assert_push_transitive_deps.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+IMAGE_DIR="$1"
+
+for blob in "$IMAGE_DIR/blobs/sha256"/*; do 
+    blob_real_path=$(realpath "$blob")
+    blob_real_path_relative="${blob_real_path##*bin/}"
+    echo "$blob -> $blob_real_path_relative"
+    if [[ ! -e "$blob_real_path_relative" ]]; then
+        echo "$blob is not present in the sandbox."
+        exit 1
+    fi 
+done

--- a/oci/private/image.bzl
+++ b/oci/private/image.bzl
@@ -171,7 +171,7 @@ def _oci_image_impl(ctx):
         args.add(ctx.file.base.path, format = "--from=%s")
         inputs.append(ctx.file.base)
         if use_symlinks:
-            transitive_inputs.append(ctx.file.base)
+            transitive_inputs += [ctx.file.base] + ctx.attr.base[DefaultInfo].default_runfiles.files.to_list()
     else:
         # create a scratch base image with given os/arch[/variant]
         args.add(_platform_str(ctx.attr.os, ctx.attr.architecture, ctx.attr.variant), format = "--scratch=%s")
@@ -234,7 +234,7 @@ def _oci_image_impl(ctx):
         action_env["MSYS_NO_PATHCONV"] = "1"
 
     ctx.actions.run(
-        inputs = inputs,
+        inputs = inputs + transitive_inputs,
         arguments = [args],
         outputs = [output],
         env = action_env,

--- a/oci/private/image.bzl
+++ b/oci/private/image.bzl
@@ -171,14 +171,16 @@ def _oci_image_impl(ctx):
         args.add(ctx.file.base.path, format = "--from=%s")
         inputs.append(ctx.file.base)
         if use_symlinks:
-            transitive_inputs += [ctx.file.base] + ctx.attr.base[DefaultInfo].default_runfiles.files.to_list()
+            base_default_info = ctx.attr.base[DefaultInfo]
+            transitive_inputs.append(base_default_info.default_runfiles.files)
+            transitive_inputs.append(base_default_info.files)
     else:
         # create a scratch base image with given os/arch[/variant]
         args.add(_platform_str(ctx.attr.os, ctx.attr.architecture, ctx.attr.variant), format = "--scratch=%s")
 
     # If tree artifact symlinks are supported also add tars into runfiles.
     if use_symlinks:
-        transitive_inputs = transitive_inputs + ctx.files.tars
+        transitive_inputs.append(depset(ctx.files.tars))
 
     # add layers
     for (i, layer) in enumerate(ctx.files.tars):
@@ -234,7 +236,7 @@ def _oci_image_impl(ctx):
         action_env["MSYS_NO_PATHCONV"] = "1"
 
     ctx.actions.run(
-        inputs = inputs + transitive_inputs,
+        inputs = depset(inputs, transitive = transitive_inputs),
         arguments = [args],
         outputs = [output],
         env = action_env,
@@ -252,7 +254,7 @@ def _oci_image_impl(ctx):
     return [
         DefaultInfo(
             files = depset([output]),
-            runfiles = ctx.runfiles(transitive_inputs),
+            runfiles = ctx.runfiles(transitive_files = depset(transitive = transitive_inputs)),
         ),
     ]
 

--- a/oci/private/load.bzl
+++ b/oci/private/load.bzl
@@ -167,6 +167,7 @@ def _load_impl(ctx):
     if ctx.file.loader:
         runtime_deps.append(ctx.file.loader)
     runfiles = ctx.runfiles(runtime_deps, transitive_files = tar_inputs)
+    runfiles = runfiles.merge(ctx.attr.image[DefaultInfo].default_runfiles)
     runfiles = runfiles.merge(ctx.attr._runfiles.default_runfiles)
 
     ctx.actions.expand_template(

--- a/oci/private/push.bzl
+++ b/oci/private/push.bzl
@@ -100,7 +100,7 @@ oci_push(
 
 # Helper rule for ensuring that the crane and yq toolchains are actually
 # resolved for the architecture we are targeting.
-def _transition_to_target_impl(settings, attr):
+def _transition_to_target_impl(settings, _attr):
     return {
         # String conversion is needed to prevent a crash with Bazel 6.x.
         "//command_line_option:extra_execution_platforms": [
@@ -205,6 +205,7 @@ def _impl(ctx):
     )
     runfiles = ctx.runfiles(files = files)
     runfiles = runfiles.merge(jq.default.default_runfiles)
+    runfiles = runfiles.merge(ctx.attr.image[DefaultInfo].default_runfiles)
     runfiles = runfiles.merge(crane.default.default_runfiles)
 
     return DefaultInfo(executable = util.maybe_wrap_launcher_for_windows(ctx, executable), runfiles = runfiles)


### PR DESCRIPTION
This has surfaced as bug in most of the places like https://github.com/bazel-contrib/rules_oci/issues/643, https://github.com/bazel-contrib/rules_oci/issues/642 (most likely). 

The problem was that when symlinks were enabled on Bazel 7, the logic did not propagate the file dependencies correctly downstream which lead to some obscure errors i have mentioned above. 

Now that we have some provider hierarchy, it makes me think if we should have a provider here, as requested in:  https://github.com/bazel-contrib/rules_oci/issues/279