### PR TITLE
fix: add history entries for tars attribute

### DIFF
--- a/e2e/assertion/wksp/MODULE.bazel
+++ b/e2e/assertion/wksp/MODULE.bazel
@@ -11,7 +11,7 @@ local_path_override(
 oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
 oci.pull(
     name = "empty_image",
-    digest = "sha256:2515b821f7cc895283a961ea6548a29f7eb340a0b8d29f79a0feb3825d31caa9",
+    digest = "sha256:814539791f475a9d74eb21fd6149849d8b5b4bb1f222185c835581ce59bc7e0a",
     image = "http://localhost:1447/empty_image",
 )
 use_repo(oci, "empty_image")

--- a/e2e/assertion/wksp/WORKSPACE
+++ b/e2e/assertion/wksp/WORKSPACE
@@ -15,7 +15,7 @@ load("@rules_oci//oci:pull.bzl", "oci_pull")
 
 oci_pull(
     name = "empty_image",
-    digest = "sha256:2515b821f7cc895283a961ea6548a29f7eb340a0b8d29f79a0feb3825d31caa9",
+    digest = "sha256:814539791f475a9d74eb21fd6149849d8b5b4bb1f222185c835581ce59bc7e0a",
     image = "http://localhost:1447/empty_image",
 )
 

--- a/examples/assert.bzl
+++ b/examples/assert.bzl
@@ -33,7 +33,8 @@ def assert_oci_config(
         os_eq = None,
         variant_eq = None,
         labels_eq = None,
-        created_eq = None):
+        created_eq = None,
+        history_eq = None):
     "assert that an oci_image has specified config metadata according to https://github.com/opencontainers/image-spec/blob/main/config.md"
     pick = []
 
@@ -71,6 +72,8 @@ def assert_oci_config(
 
     if created_eq:
         config_json["created"] = created_eq
+    if history_eq:
+        config_json["history"] = history_eq
 
     pick += ["." + k for k in config_json.keys()]
 

--- a/examples/assertion/BUILD.bazel
+++ b/examples/assertion/BUILD.bazel
@@ -385,6 +385,43 @@ sh_test(
     data = [":case12"],
 )
 
+# Case 13: image should have history entries
+tar(
+    name = "case13_empty_tar",
+    srcs = [],
+)
+
+tar(
+    name = "case13_empty_tar2",
+    srcs = [],
+)
+
+oci_image(
+    name = "case13",
+    architecture = "arm64",
+    os = "linux",
+    tars = [
+        ":case13_empty_tar",
+        ":case13_empty_tar2",
+    ],
+)
+
+assert_oci_config(
+    name = "test_case13",
+    history_eq = [
+        {
+            "created": "1970-01-01T00:00:00Z",
+            "created_by": "bazel build //examples/assertion:case13_empty_tar",
+        },
+        {
+            "created": "1970-01-01T00:00:00Z",
+            "created_by": "bazel build //examples/assertion:case13_empty_tar2",
+        },
+    ],
+    image = ":case13",
+)
+
+
 # Case 14: created property should be epoch start
 oci_image(
     name = "case14",

--- a/examples/multi_architecture_image/BUILD.bazel
+++ b/examples/multi_architecture_image/BUILD.bazel
@@ -43,5 +43,5 @@ genrule(
 assert_contains(
     name = "check_digest",
     actual = ":hash",
-    expected = "sha256:9cc41e3583d5385aa6adc686c15f4e4625ec46fceabde54146add048aa95e716",
+    expected = "sha256:a2b8ae94672721788b67874f27cf3574fada3ccccc69f483bcb43de653573fe0",
 )

--- a/oci/private/descriptor.sh
+++ b/oci/private/descriptor.sh
@@ -14,6 +14,7 @@ set -o pipefail -o errexit -o nounset
 PATH="$HPATH:$PATH"
 archive="$1"
 output="$2"
+label="$3"
 
 digest="$(regctl digest <"$archive")"
 diffid="$digest"
@@ -28,5 +29,19 @@ elif zstd -t <"$archive" 2>/dev/null; then
     diffid=$(zstd --decompress --format=zstd <"$archive" | regctl digest)
 fi
 
-jq -n --arg compression "$compression" --arg diffid "$diffid" --arg digest "$digest" --argjson size "$size" \
-    '{digest: $digest, diffid: $diffid, compression: $compression, size: $size }' >"$output"
+jq -n \
+    --arg compression "$compression" \
+    --arg diffid "$diffid" \
+    --arg digest "$digest" \
+    --argjson size "$size" \
+    --arg label "$label" \
+'{
+    digest: $digest, 
+    diffid: $diffid, 
+    compression: $compression, 
+    size: $size,
+    history: {
+        created: "1970-01-01T00:00:00Z",
+        created_by: "bazel build \($label)"
+    }
+}' >"$output"

--- a/oci/private/image.bzl
+++ b/oci/private/image.bzl
@@ -105,6 +105,7 @@ def _calculate_descriptor(ctx, idx, layer, zstd, jq, coreutils, regctl):
     args = ctx.actions.args()
     args.add(layer)
     args.add(descriptor)
+    args.add(layer.owner)
     ctx.actions.run(
         executable = util.maybe_wrap_launcher_for_windows(ctx, ctx.executable._descriptor_sh),
         inputs = [layer],

--- a/oci/private/image.sh
+++ b/oci/private/image.sh
@@ -27,7 +27,7 @@ function base_from_scratch() {
     layers: []
   }' | update_manifest
   # Create the image config when there is annotations
-  jq -n --argjson platform "$platform" '{created: "1970-01-01T00:00:00Z", config:{}, rootfs:{type: "layers", diff_ids:[]}} + $platform' | update_config >/dev/null
+  jq -n --argjson platform "$platform" '{created: "1970-01-01T00:00:00Z", config:{}, history:[], rootfs:{type: "layers", diff_ids:[]}} + $platform' | update_config >/dev/null
 }
 
 function base_from() {
@@ -91,7 +91,7 @@ function add_layer() {
   desc="$(jq --arg comp_ext "${comp_ext}" '.compression |= (if . != "" then "\($comp_ext)\(.)" end)' <<< "$desc")"
 
   new_config_digest=$(
-    get_config | jq --argjson desc "$desc" '.rootfs.diff_ids += [$desc.diffid]' | update_config
+    get_config | jq --argjson desc "$desc" '.rootfs.diff_ids += [$desc.diffid] | .history += [$desc.history]' | update_config
   )
 
   get_manifest |


### PR DESCRIPTION
image-spec says that this field is optional, however some systems like seen in https://github.com/bazel-contrib/rules_oci/issues/645 require this field. Also, skipping history entries lead to broken images if the base image already had one. 

fixes https://github.com/bazel-contrib/rules_oci/issues/645