### PR TITLE
fix: set created property for scratch base

### DIFF
--- a/e2e/assertion/wksp/MODULE.bazel
+++ b/e2e/assertion/wksp/MODULE.bazel
@@ -11,7 +11,7 @@ local_path_override(
 oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
 oci.pull(
     name = "empty_image",
-    digest = "sha256:e40e202a677ddddeaaf4603df278a6da42130d750622f1b1130bdafe6876a6e0",
+    digest = "sha256:2515b821f7cc895283a961ea6548a29f7eb340a0b8d29f79a0feb3825d31caa9",
     image = "http://localhost:1447/empty_image",
 )
 use_repo(oci, "empty_image")

--- a/e2e/assertion/wksp/WORKSPACE
+++ b/e2e/assertion/wksp/WORKSPACE
@@ -15,7 +15,7 @@ load("@rules_oci//oci:pull.bzl", "oci_pull")
 
 oci_pull(
     name = "empty_image",
-    digest = "sha256:e40e202a677ddddeaaf4603df278a6da42130d750622f1b1130bdafe6876a6e0",
+    digest = "sha256:2515b821f7cc895283a961ea6548a29f7eb340a0b8d29f79a0feb3825d31caa9",
     image = "http://localhost:1447/empty_image",
 )
 

--- a/examples/assert.bzl
+++ b/examples/assert.bzl
@@ -32,7 +32,8 @@ def assert_oci_config(
         architecture_eq = None,
         os_eq = None,
         variant_eq = None,
-        labels_eq = None):
+        labels_eq = None,
+        created_eq = None):
     "assert that an oci_image has specified config metadata according to https://github.com/opencontainers/image-spec/blob/main/config.md"
     pick = []
 
@@ -67,6 +68,9 @@ def assert_oci_config(
         config_json["architecture"] = architecture_eq
     if variant_eq:
         config_json["variant"] = variant_eq
+
+    if created_eq:
+        config_json["created"] = created_eq
 
     pick += ["." + k for k in config_json.keys()]
 

--- a/examples/assertion/BUILD.bazel
+++ b/examples/assertion/BUILD.bazel
@@ -385,6 +385,19 @@ sh_test(
     data = [":case12"],
 )
 
+# Case 14: created property should be epoch start
+oci_image(
+    name = "case14",
+    architecture = "arm64",
+    os = "linux",
+)
+
+assert_oci_config(
+    name = "test_case14",
+    created_eq = "1970-01-01T00:00:00Z",
+    image = ":case14",
+)
+
 # Case 15: Setting entrypoint resets cmd
 oci_image(
     name = "case15_base",

--- a/oci/private/image.sh
+++ b/oci/private/image.sh
@@ -27,7 +27,7 @@ function base_from_scratch() {
     layers: []
   }' | update_manifest
   # Create the image config when there is annotations
-  jq -n --argjson platform "$platform" '{config:{}, rootfs:{type: "layers", diff_ids:[]}} + $platform' | update_config >/dev/null
+  jq -n --argjson platform "$platform" '{created: "1970-01-01T00:00:00Z", config:{}, rootfs:{type: "layers", diff_ids:[]}} + $platform' | update_config >/dev/null
 }
 
 function base_from() {


### PR DESCRIPTION
This is a follow-up to https://github.com/bazel-contrib/rules_oci/pull/654 for consistency. 

Also fixes an old issue: https://github.com/bazel-contrib/rules_oci/issues/438