### PR TITLE
fix typo in load.sh.tpl

### DIFF
--- a/oci/private/load.sh.tpl
+++ b/oci/private/load.sh.tpl
@@ -9,7 +9,7 @@ readonly TAR="$(rlocation "{{tar}}")"
 readonly MTREE="$(rlocation "{{mtree_path}}")"
 readonly LOADER="$(rlocation "{{loader}}")"
 
-if [ -e "$LOADER}" ]; then
+if [ -e "$LOADER" ]; then
     CONTAINER_CLI="$LOADER"
 elif command -v docker &> /dev/null; then
     CONTAINER_CLI="docker"

--- a/oci/private/load.sh.tpl
+++ b/oci/private/load.sh.tpl
@@ -9,7 +9,7 @@ readonly TAR="$(rlocation "{{tar}}")"
 readonly MTREE="$(rlocation "{{mtree_path}}")"
 readonly LOADER="$(rlocation "{{loader}}")"
 
-if [ -e "$LOADER" ]; then
+if [ -f "$LOADER" ]; then
     CONTAINER_CLI="$LOADER"
 elif command -v docker &> /dev/null; then
     CONTAINER_CLI="docker"


### PR DESCRIPTION
Currently the generated template looks like

```bash
if [ -e "$LOADER}" ]; then
    CONTAINER_CLI="$LOADER"
elif command -v docker &> /dev/null; then
    CONTAINER_CLI="docker"
# ...
```

This will never evaluate the first if clause, because `$LOADER}` will for an empty `LOADER` expand to `}`.