### PR TITLE
test: add test for setting entrypoint to []

### DIFF
--- a/examples/assertion/BUILD.bazel
+++ b/examples/assertion/BUILD.bazel
@@ -421,7 +421,6 @@ assert_oci_config(
     image = ":case13",
 )
 
-
 # Case 14: created property should be epoch start
 oci_image(
     name = "case14",
@@ -482,6 +481,42 @@ assert_oci_config(
     cmd_eq = ["--arg"],
     entrypoint_eq = ["/custom_bin"],
     image = ":case15_cmd",
+)
+
+# Case 16: allow setting entrypoint to `[]`
+# See: https://github.com/bazel-contrib/rules_oci/issues/336
+oci_image(
+    name = "case16_base",
+    architecture = "arm64",
+    cmd = [
+        "-c",
+        "test",
+    ],
+    entrypoint = ["/bin/bash"],
+    os = "linux",
+)
+
+assert_oci_config(
+    name = "test_case16_base",
+    cmd_eq = [
+        "-c",
+        "test",
+    ],
+    entrypoint_eq = ["/bin/bash"],
+    image = ":case16_base",
+)
+
+oci_image(
+    name = "case16",
+    base = ":case16_base",
+    entrypoint = [],
+)
+
+assert_oci_config(
+    name = "test_case16",
+    cmd_eq = None,
+    entrypoint_eq = [],
+    image = ":case16",
 )
 
 # build them as test.


### PR DESCRIPTION
Turns out we fixed this accidentially when we implemented support for stamping of `entrypoint` and `cmd`. 

Closes https://github.com/bazel-contrib/rules_oci/issues/336