### PR TITLE
chore: remove deprecated config_path attribute

### DIFF
--- a/docs/pull.md
+++ b/docs/pull.md
@@ -94,7 +94,7 @@ See the [examples/credential_helper](/examples/credential_helper/auth.sh) direct
 
 <pre>
 oci_pull(<a href="#oci_pull-name">name</a>, <a href="#oci_pull-image">image</a>, <a href="#oci_pull-repository">repository</a>, <a href="#oci_pull-registry">registry</a>, <a href="#oci_pull-platforms">platforms</a>, <a href="#oci_pull-digest">digest</a>, <a href="#oci_pull-tag">tag</a>, <a href="#oci_pull-reproducible">reproducible</a>, <a href="#oci_pull-is_bzlmod">is_bzlmod</a>, <a href="#oci_pull-config">config</a>,
-         <a href="#oci_pull-config_path">config_path</a>, <a href="#oci_pull-bazel_tags">bazel_tags</a>)
+         <a href="#oci_pull-bazel_tags">bazel_tags</a>)
 </pre>
 
 Repository macro to fetch image manifest data from a remote docker registry.
@@ -122,7 +122,6 @@ in rules like `oci_image`.
 | <a id="oci_pull-reproducible"></a>reproducible |  Set to False to silence the warning about reproducibility when using <code>tag</code>.   |  <code>True</code> |
 | <a id="oci_pull-is_bzlmod"></a>is_bzlmod |  whether the oci_pull is being called from a module extension   |  <code>False</code> |
 | <a id="oci_pull-config"></a>config |  Label to a <code>.docker/config.json</code> file.   |  <code>None</code> |
-| <a id="oci_pull-config_path"></a>config_path |  Deprecated. use <code>config</code> attribute or DOCKER_CONFIG environment variable.   |  <code>None</code> |
 | <a id="oci_pull-bazel_tags"></a>bazel_tags |  Bazel tags to be propagated to generated rules.   |  <code>[]</code> |
 
 

--- a/oci/private/pull.bzl
+++ b/oci/private/pull.bzl
@@ -28,11 +28,6 @@ _IMAGE_REFERENCE_ATTRS = {
         doc = "Label to a .docker/config.json file",
         allow_single_file = True,
     ),
-    "config_path": attr.label(
-        # TODO(2.0): remove
-        doc = "Deprecated. Use DOCKER_CONFIG environment variable or config attribute instead. TODO(2.0): remove",
-        allow_single_file = True,
-    ),
 }
 
 SCHEMA1_ERROR = """\
@@ -72,11 +67,7 @@ _DOWNLOAD_HEADERS = {
 def _config_path(rctx):
     if rctx.attr.config:
         return rctx.path(rctx.attr.config)
-    elif rctx.attr.config_path:
-        util.warning(rctx, "attribute config_path is deprecated and will be removed in 2.0. use DOCKER_CONFIG environment variable or config attribute instead.")
-        return rctx.path(rctx.attr.config_path)
-    else:
-        return None
+    return None
 
 def _is_tag(str):
     return str.find(":") == -1

--- a/oci/pull.bzl
+++ b/oci/pull.bzl
@@ -103,7 +103,7 @@ _PLATFORM_TO_BAZEL_CPU = {
     "linux/mips64le": "@platforms//cpu:mips64",
 }
 
-def oci_pull(name, image = None, repository = None, registry = None, platforms = None, digest = None, tag = None, reproducible = True, is_bzlmod = False, config = None, config_path = None, bazel_tags = []):
+def oci_pull(name, image = None, repository = None, registry = None, platforms = None, digest = None, tag = None, reproducible = True, is_bzlmod = False, config = None, bazel_tags = []):
     """Repository macro to fetch image manifest data from a remote docker registry.
 
     To use the resulting image, you can use the `@wkspc` shorthand label, for example
@@ -136,7 +136,6 @@ def oci_pull(name, image = None, repository = None, registry = None, platforms =
             Since tags are mutable, this is not reproducible, so a warning is printed.
         reproducible: Set to False to silence the warning about reproducibility when using `tag`.
         config: Label to a `.docker/config.json` file.
-        config_path: Deprecated. use `config` attribute or DOCKER_CONFIG environment variable.
         is_bzlmod: whether the oci_pull is being called from a module extension
         bazel_tags: Bazel tags to be propagated to generated rules.
     """
@@ -183,8 +182,6 @@ def oci_pull(name, image = None, repository = None, registry = None, platforms =
                 platform = plat,
                 target_name = plat_name,
                 config = config,
-                # TODO(2.0): remove
-                config_path = config_path,
                 bazel_tags = bazel_tags,
             )
 
@@ -208,8 +205,6 @@ def oci_pull(name, image = None, repository = None, registry = None, platforms =
             identifier = digest or tag,
             target_name = single_platform,
             config = config,
-            # TODO(2.0): remove
-            config_path = config_path,
             bazel_tags = bazel_tags,
         )
 
@@ -227,6 +222,4 @@ def oci_pull(name, image = None, repository = None, registry = None, platforms =
         bzlmod_repository = name if is_bzlmod else None,
         reproducible = reproducible,
         config = config,
-        # TODO(2.0): remove
-        config_path = config_path,
     )


### PR DESCRIPTION
Removes the deprecated config_path attribute. Replacement is to use `config` attribute which accepts a label, or use `DOCKER_CONFIG` standard env for cases such as overriding the config in CI.