### PR TITLE
fix: ensures confugure_buildx rule runs when bazel server restarts

### DIFF
--- a/examples/dockerfile/buildx.bzl
+++ b/examples/dockerfile/buildx.bzl
@@ -38,6 +38,7 @@ BUILDER_NAME = "%s"
 
 configure_buildx = repository_rule(
     implementation = _impl_configure_buildx,
+    local = True,
 )
 
 def fetch_buildx():


### PR DESCRIPTION
Ensures that buildx builder gets recreated

Reproduced the issue in GitHub Actions with cache of repositories and external dependencies. The issue:
```
ERROR: /home/runner/work/xxx/BUILD.bazel:16:11: BuildDocker xxx/base failed: (Exit 1): buildx failed: error executing BuildDocker command (from target //xxx:base) bazel-out/k8-opt-exec-ST-a828a81199fe/bin/xxx/buildx build xxx --builder builder-docker ... (remaining 1 argument skipped)
ERROR: no builder "builder-docker" found
```

The fix is based on the following doc statement: https://arc.net/l/quote/fxyvuetr

PS. I am not an expert in bazel and my fix may be incorrect. I am welcome to a different solution