### PR TITLE
Fix for gnu xargs and send --verbose to other commands

### DIFF
--- a/oci/private/push.sh.tpl
+++ b/oci/private/push.sh.tpl
@@ -8,6 +8,8 @@ readonly TAGS_FILE="{{tags}}"
 readonly FIXED_ARGS=({{fixed_args}})
 readonly REPOSITORY_FILE="{{repository_file}}"
 
+VERBOSE=""
+
 REPOSITORY=""
 if [ -f $REPOSITORY_FILE ] ; then
   REPOSITORY=$(tr -d '\n' < "$REPOSITORY_FILE")
@@ -24,6 +26,9 @@ ARGS=()
 
 while (( $# > 0 )); do
   case $1 in
+    (-v|--verbose)
+      VERBOSE="--verbose"
+      shift;;
     (-t|--tag)
       TAGS+=( "$2" )
       shift
@@ -47,13 +52,13 @@ done
 DIGEST=$("${JQ}" -r '.manifests[0].digest' "${IMAGE_DIR}/index.json")
 
 REFS=$(mktemp)
-"${CRANE}" push "${IMAGE_DIR}" "${REPOSITORY}@${DIGEST}" "${ARGS[@]+"${ARGS[@]}"}" --image-refs "${REFS}"
+"${CRANE}" push ${VERBOSE} "${IMAGE_DIR}" "${REPOSITORY}@${DIGEST}" "${ARGS[@]+"${ARGS[@]}"}" --image-refs "${REFS}"
 
 for tag in "${TAGS[@]+"${TAGS[@]}"}"
 do
-  "${CRANE}" tag $(cat "${REFS}") "${tag}"
+  "${CRANE}" tag ${VERBOSE} $(cat "${REFS}") "${tag}"
 done
 
 if [[ -e "${TAGS_FILE:-}" ]]; then
-  cat "${TAGS_FILE}" | xargs -n1 "${CRANE}" tag $(cat "${REFS}")
+  cat "${TAGS_FILE}" | xargs -rn1 "${CRANE}" tag ${VERBOSE} $(cat "${REFS}")
 fi

--- a/oci/private/push.sh.tpl
+++ b/oci/private/push.sh.tpl
@@ -60,5 +60,5 @@ do
 done
 
 if [[ -e "${TAGS_FILE:-}" ]]; then
-  cat "${TAGS_FILE}" | xargs -rn1 "${CRANE}" tag ${VERBOSE} $(cat "${REFS}")
+  cat "${TAGS_FILE}" | xargs --no-run-if-empty -n1 "${CRANE}" tag ${VERBOSE} $(cat "${REFS}")
 fi


### PR DESCRIPTION
There's two things here:

When passing `-v` or `--verbose` to the push, it only propagates to the first crane command. This adds it to the tag pushes as well to help with debugging.

When the tags file is empty, GNU xargs was causing a failure. This is because [GNU xargs](https://www.gnu.org/software/findutils/manual/html_node/find_html/xargs-options.html) executes the command once even if the input is empty, so `crane` was raising an exception about the wrong number of arguments. Passing `-r` will give xargs the same behavior as BSD xargs. in BSD xargs, `-r` is a no-op.