### PR TITLE
make `oci_image()` accept a file for workdir

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -85,7 +85,7 @@ oci_image(
 | <a id="oci_image_rule-user"></a>user |  The <code>username</code> or <code>UID</code> which is a platform-specific structure that allows specific control over which user the process run as. This acts as a default value to use when the value is not specified when creating a container. For Linux based systems, all of the following are valid: <code>user</code>, <code>uid</code>, <code>user:group</code>, <code>uid:gid</code>, <code>uid:group</code>, <code>user:gid</code>. If <code>group/gid</code> is not specified, the default group and supplementary groups of the given <code>user/uid</code> in <code>/etc/passwd</code> from the container are applied.   | String | optional | <code>""</code> |
 | <a id="oci_image_rule-variant"></a>variant |  The variant of the specified CPU architecture. eg: <code>v6</code>, <code>v7</code>, <code>v8</code>. See: https://github.com/opencontainers/image-spec/blob/main/image-index.md#platform-variants for more.   | String | optional | <code>""</code> |
 | <a id="oci_image_rule-volumes"></a>volumes |  A file containing a comma separated list of volumes. (e.g. /srv/data,/srv/other-data)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="oci_image_rule-workdir"></a>workdir |  Sets the current working directory of the <code>entrypoint</code> process in the container. This value acts as a default and may be replaced by a working directory specified when creating a container.   | String | optional | <code>""</code> |
+| <a id="oci_image_rule-workdir"></a>workdir |  A file containing the path to the current working directory of the <code>entrypoint</code> process in the container. This value acts as a default and may be replaced by a working directory specified when runninng the container.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 
 
 <a id="oci_image"></a>
@@ -93,21 +93,28 @@ oci_image(
 ## oci_image
 
 <pre>
-oci_image(<a href="#oci_image-name">name</a>, <a href="#oci_image-labels">labels</a>, <a href="#oci_image-annotations">annotations</a>, <a href="#oci_image-env">env</a>, <a href="#oci_image-cmd">cmd</a>, <a href="#oci_image-entrypoint">entrypoint</a>, <a href="#oci_image-exposed_ports">exposed_ports</a>, <a href="#oci_image-volumes">volumes</a>, <a href="#oci_image-kwargs">kwargs</a>)
+oci_image(<a href="#oci_image-name">name</a>, <a href="#oci_image-labels">labels</a>, <a href="#oci_image-annotations">annotations</a>, <a href="#oci_image-env">env</a>, <a href="#oci_image-cmd">cmd</a>, <a href="#oci_image-entrypoint">entrypoint</a>, <a href="#oci_image-workdir">workdir</a>, <a href="#oci_image-exposed_ports">exposed_ports</a>, <a href="#oci_image-volumes">volumes</a>, <a href="#oci_image-kwargs">kwargs</a>)
 </pre>
 
 Macro wrapper around [oci_image_rule](#oci_image_rule).
 
-Allows labels and annotations to be provided as a dictionary, in addition to a text file.
-See https://github.com/opencontainers/image-spec/blob/main/annotations.md
+This wrapper allows (some) parameters to be specified as a list or dict, or
+as a target text file containing the contents. This accomodes rules to auto
+generate some of these items.
 
-Label/annotation/env can by configured using either dict(key-&gt;value) or a file that contains key=value pairs
+Produces a target `[name].digest`, whose default output is a file containing the sha256 digest of the resulting image.
+This is similar to the same-named target created by rules_docker's `container_image` macro.
+
+**DICT_OR_LABEL**: `label`, `annotation`, `env`
+
+Can by configured using either dict(key-&gt;value) or a file that contains key=value pairs
 (one per line). The file can be preprocessed using (e.g. using `jq`) to supply external (potentially not
 deterministic) information when running with `--stamp` flag.  See the example in
 [/examples/labels/BUILD.bazel](https://github.com/bazel-contrib/rules_oci/blob/main/examples/labels/BUILD.bazel).
 
-Produces a target `[name].digest`, whose default output is a file containing the sha256 digest of the resulting image.
-This is similar to the same-named target created by rules_docker's `container_image` macro.
+**LIST_OR_LABEL**: `cmd`, `entrypoint`, `workdir`, `exposed_ports`, `volumes`
+
+Can be a list of strings, or a file with newlines separating entries.
 
 
 **PARAMETERS**
@@ -116,13 +123,14 @@ This is similar to the same-named target created by rules_docker's `container_im
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="oci_image-name"></a>name |  name of resulting oci_image_rule   |  none |
-| <a id="oci_image-labels"></a>labels |  Labels for the image config. See documentation above.   |  <code>None</code> |
-| <a id="oci_image-annotations"></a>annotations |  Annotations for the image config. See documentation above.   |  <code>None</code> |
-| <a id="oci_image-env"></a>env |  Environment variables provisioned by default to the running container. See documentation above.   |  <code>None</code> |
-| <a id="oci_image-cmd"></a>cmd |  Command & argument configured by default in the running container. See documentation above.   |  <code>None</code> |
-| <a id="oci_image-entrypoint"></a>entrypoint |  Entrypoint configured by default in the running container. See documentation above.   |  <code>None</code> |
-| <a id="oci_image-exposed_ports"></a>exposed_ports |  Exposed ports in the running container. See documentation above.   |  <code>None</code> |
-| <a id="oci_image-volumes"></a>volumes |  Volumes for the container. See documentation above.   |  <code>None</code> |
+| <a id="oci_image-labels"></a>labels |  <code>DICT_OR_LABEL</code> Labels for the image config.   |  <code>None</code> |
+| <a id="oci_image-annotations"></a>annotations |  <code>DICT_OR_LABEL</code> Annotations for the image config.   |  <code>None</code> |
+| <a id="oci_image-env"></a>env |  <code>DICT_OR_LABEL</code> Environment variables provisioned by default to the running container.   |  <code>None</code> |
+| <a id="oci_image-cmd"></a>cmd |  <code>LIST_OR_LABEL</code> Command & argument configured by default in the running container.   |  <code>None</code> |
+| <a id="oci_image-entrypoint"></a>entrypoint |  <code>LIST_OR_LABEL</code> Entrypoint configured by default in the running container.   |  <code>None</code> |
+| <a id="oci_image-workdir"></a>workdir |  <code>LIST_OR_LABEL</code> Workdir configured by default in the running container. Only 1 list entry allowed.   |  <code>None</code> |
+| <a id="oci_image-exposed_ports"></a>exposed_ports |  <code>LIST_OR_LABEL</code> Exposed ports in the running container.   |  <code>None</code> |
+| <a id="oci_image-volumes"></a>volumes |  <code>LIST_OR_LABEL</code> Volumes for the container.   |  <code>None</code> |
 | <a id="oci_image-kwargs"></a>kwargs |  other named arguments to [oci_image_rule](#oci_image_rule) and [common rule attributes](https://bazel.build/reference/be/common-definitions#common-attributes).   |  none |
 
 

--- a/docs/image.md
+++ b/docs/image.md
@@ -112,9 +112,13 @@ Can by configured using either dict(key-&gt;value) or a file that contains key=v
 deterministic) information when running with `--stamp` flag.  See the example in
 [/examples/labels/BUILD.bazel](https://github.com/bazel-contrib/rules_oci/blob/main/examples/labels/BUILD.bazel).
 
-**LIST_OR_LABEL**: `cmd`, `entrypoint`, `workdir`, `exposed_ports`, `volumes`
+**LIST_OR_LABEL**: `cmd`, `entrypoint`, `exposed_ports`, `volumes`
 
 Can be a list of strings, or a file with newlines separating entries.
+
+**STRING_OR_LABEL**: `workdir`
+
+A string, or a target text file whose output contains a single line
 
 
 **PARAMETERS**
@@ -128,7 +132,7 @@ Can be a list of strings, or a file with newlines separating entries.
 | <a id="oci_image-env"></a>env |  <code>DICT_OR_LABEL</code> Environment variables provisioned by default to the running container.   |  <code>None</code> |
 | <a id="oci_image-cmd"></a>cmd |  <code>LIST_OR_LABEL</code> Command & argument configured by default in the running container.   |  <code>None</code> |
 | <a id="oci_image-entrypoint"></a>entrypoint |  <code>LIST_OR_LABEL</code> Entrypoint configured by default in the running container.   |  <code>None</code> |
-| <a id="oci_image-workdir"></a>workdir |  <code>LIST_OR_LABEL</code> Workdir configured by default in the running container. Only 1 list entry allowed.   |  <code>None</code> |
+| <a id="oci_image-workdir"></a>workdir |  <code>STRING_OR_LABEL</code> Workdir configured by default in the running container.   |  <code>None</code> |
 | <a id="oci_image-exposed_ports"></a>exposed_ports |  <code>LIST_OR_LABEL</code> Exposed ports in the running container.   |  <code>None</code> |
 | <a id="oci_image-volumes"></a>volumes |  <code>LIST_OR_LABEL</code> Volumes for the container.   |  <code>None</code> |
 | <a id="oci_image-kwargs"></a>kwargs |  other named arguments to [oci_image_rule](#oci_image_rule) and [common rule attributes](https://bazel.build/reference/be/common-definitions#common-attributes).   |  none |

--- a/examples/assertion/BUILD.bazel
+++ b/examples/assertion/BUILD.bazel
@@ -190,7 +190,7 @@ oci_image(
     volumes = ["/srv/data"],
     # user & workdir
     user = "root",
-    workdir = "/root",
+    workdir = ["/root"],
     # labels & annotations
     labels = {
         "org.opencontainers.image.version": "0.0.0",
@@ -618,4 +618,23 @@ build_test(
         ":case5_tar",
         ":case10_run",
     ],
+)
+
+# Case 21: accept workdir param as a target (list input tested in case8)
+genrule(
+    name = "case21_workdir_target",
+    outs = ["case21_workdir_target.txt"],
+    cmd = "echo -n /workdir > $@",
+)
+
+oci_image(
+    name = "case21",
+    base = ":case8",
+    workdir = ":case21_workdir_target",
+)
+
+assert_oci_config(
+    name = "test_case21",
+    image = ":case21",
+    workdir_eq = "/workdir",
 )

--- a/examples/assertion/BUILD.bazel
+++ b/examples/assertion/BUILD.bazel
@@ -190,7 +190,7 @@ oci_image(
     volumes = ["/srv/data"],
     # user & workdir
     user = "root",
-    workdir = ["/root"],
+    workdir = "/root",
     # labels & annotations
     labels = {
         "org.opencontainers.image.version": "0.0.0",
@@ -620,7 +620,7 @@ build_test(
     ],
 )
 
-# Case 21: accept workdir param as a target (list input tested in case8)
+# Case 21: accept workdir param as a target label (string input is tested in case8)
 genrule(
     name = "case21_workdir_target",
     outs = ["case21_workdir_target.txt"],
@@ -630,7 +630,7 @@ genrule(
 oci_image(
     name = "case21",
     base = ":case8",
-    workdir = ":case21_workdir_target",
+    workdir = "case21_workdir_target",
 )
 
 assert_oci_config(

--- a/oci/private/image.bzl
+++ b/oci/private/image.bzl
@@ -81,7 +81,7 @@ This acts as a default value to use when the value is not specified when creatin
 For Linux based systems, all of the following are valid: `user`, `uid`, `user:group`, `uid:gid`, `uid:group`, `user:gid`.
 If `group/gid` is not specified, the default group and supplementary groups of the given `user/uid` in `/etc/passwd` from the container are applied.
 """),
-    "workdir": attr.string(doc = "Sets the current working directory of the `entrypoint` process in the container. This value acts as a default and may be replaced by a working directory specified when creating a container."),
+    "workdir": attr.label(doc = "A file containing the path to the current working directory of the `entrypoint` process in the container. This value acts as a default and may be replaced by a working directory specified when runninng the container.", allow_single_file = True),
     "exposed_ports": attr.label(doc = "A file containing a comma separated list of exposed ports. (e.g. 2000/tcp, 3000/udp or 4000. No protocol defaults to tcp).", allow_single_file = True),
     "volumes": attr.label(doc = "A file containing a comma separated list of volumes. (e.g. /srv/data,/srv/other-data)", allow_single_file = True),
     "os": attr.string(doc = "The name of the operating system which the image is built to run on. eg: `linux`, `windows`. See $GOOS documentation for possible values: https://go.dev/doc/install/source#environment"),
@@ -227,7 +227,8 @@ def _oci_image_impl(ctx):
         args.add(ctx.attr.user, format = "--user=%s")
 
     if ctx.attr.workdir:
-        args.add(ctx.attr.workdir, format = "--workdir=%s")
+        args.add(ctx.file.workdir.path, format = "--workdir=%s")
+        inputs.append(ctx.file.workdir)
 
     action_env = {}
 

--- a/oci/private/image.sh
+++ b/oci/private/image.sh
@@ -164,7 +164,7 @@ for ARG in "$@"; do
     CONFIG=$(jq --arg user "${ARG#--user=}" '.config.User = $user' <<<"$CONFIG")
     ;;
   --workdir=*)
-    CONFIG=$(jq --arg workdir "${ARG#--workdir=}" '.config.WorkingDir = $workdir' <<<"$CONFIG")
+    CONFIG=$(jq --rawfile workdir "${ARG#--workdir=}" '.config.WorkingDir = $workdir' <<<"$CONFIG")
     ;;
   --labels=*)
     CONFIG=$(jq --rawfile labels "${ARG#--labels=}" '.config.Labels += ($labels | split("\n") | map(select(. | length > 0)) | map(. | split("=")) | map({key: .[0], value: .[1:] | join("=")}) | from_entries)' <<<"$CONFIG")

--- a/oci/tests/BUILD.bazel
+++ b/oci/tests/BUILD.bazel
@@ -2,6 +2,7 @@ load("@aspect_bazel_lib//lib:diff_test.bzl", "diff_test")
 load("@aspect_bazel_lib//lib:run_binary.bzl", "run_binary")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load(":pull_tests.bzl", "parse_image_test")
+load("//oci:defs.bzl", "test_is_a_workdir_label")
 
 IMAGES_TO_TEST = {
     "linux/amd64": {
@@ -83,3 +84,5 @@ build_test(
 )
 
 parse_image_test(name = "parse_image_test")
+
+test_is_a_workdir_label()


### PR DESCRIPTION
This clones much of the same logic as `entrypoint` and friends. Also refactor docstring a little to illuminate "wrapper vs the rule" and the dual typed args.