### PR TITLE
refactor: remove mtree as the default output

### DIFF
--- a/oci/private/load.bzl
+++ b/oci/private/load.bzl
@@ -218,7 +218,6 @@ def _load_impl(ctx):
 
     return [
         DefaultInfo(
-            files = depset([mtree_spec]),
             runfiles = runfiles,
             executable = runnable_loader,
         ),


### PR DESCRIPTION
BREAKING CHANGE:

It's unfortunate that we make a breaking change in an RC phase, but we haven't seen anybody using this output so far. 


Removal of the mtree as the default output allows `$(location :oci_load_label)` to return the `executable` instead of the `DefaultInfo.files[0]` which what most expect.