### PR TITLE
Add a plus sign to the output_groups option

### DIFF
--- a/docs/load.md
+++ b/docs/load.md
@@ -41,7 +41,7 @@ so producing it only creates unnecessary load on the action cache.
 
 If needed, the `tarball` output group allows you to depend on the tar output from another rule.
 
-On the command line, `bazel build //path/to:my_tarball --output_groups=tarball`
+On the command line, `bazel build //path/to:my_tarball --output_groups=+tarball`
 
 or in a BUILD file:
 

--- a/oci/private/load.bzl
+++ b/oci/private/load.bzl
@@ -34,7 +34,7 @@ so producing it only creates unnecessary load on the action cache.
 
 If needed, the `tarball` output group allows you to depend on the tar output from another rule.
 
-On the command line, `bazel build //path/to:my_tarball --output_groups=tarball`
+On the command line, `bazel build //path/to:my_tarball --output_groups=+tarball`
 
 or in a BUILD file:
 


### PR DESCRIPTION
For people upgrading from earlier versions of rules_oci, it works out better to use `+tarball` than `tarball`. With the docs as currently written, without the plus sign, it will break for anyone using an earlier version of rules_oci. Adding the plus makes it work with either older or newer versions of rules_oci, which is convenient for people who are upgrading incrementally.

It's probably a good habit, anyway, to use the plus. When you want an extra output group to a build, you usually don't want to cancel all the output groups you don't know about. You just want to add the one new one that you do care about.