### PR TITLE
fix: pass global args to all crane invocations

### DIFF
--- a/oci/private/push.sh.tpl
+++ b/oci/private/push.sh.tpl
@@ -52,13 +52,13 @@ done
 DIGEST=$("${JQ}" -r '.manifests[0].digest' "${IMAGE_DIR}/index.json")
 
 REFS=$(mktemp)
-"${CRANE}" push ${VERBOSE} "${IMAGE_DIR}" "${REPOSITORY}@${DIGEST}" "${ARGS[@]+"${ARGS[@]}"}" --image-refs "${REFS}"
+"${CRANE}" push ${VERBOSE} "${IMAGE_DIR}" "${REPOSITORY}@${DIGEST}" "${ARGS[@]}" --image-refs "${REFS}"
 
 for tag in "${TAGS[@]+"${TAGS[@]}"}"
 do
-  "${CRANE}" tag ${VERBOSE} $(cat "${REFS}") "${tag}"
+  "${CRANE}" tag ${VERBOSE} "${ARGS[@]}" $(cat "${REFS}") "${tag}"
 done
 
 if [[ -e "${TAGS_FILE:-}" ]]; then
-  cat "${TAGS_FILE}" | xargs -r -n1 "${CRANE}" tag ${VERBOSE} $(cat "${REFS}")
+  cat "${TAGS_FILE}" | xargs -r -n1 "${CRANE}" tag ${VERBOSE} "${ARGS[@]}" $(cat "${REFS}")
 fi


### PR DESCRIPTION
This fixes #527. Please let me know if I missed anything. Thanks!