### PR TITLE
fix: Support loading tarballs with older podman

### DIFF
--- a/oci/private/load.sh.tpl
+++ b/oci/private/load.sh.tpl
@@ -28,6 +28,5 @@ mtree_contents="$(cat $MTREE)"
 mtree_contents="${mtree_contents//"$image_root"/}"
 mtree_contents="${mtree_contents//"$manifest_root"/}"
 
-"$CONTAINER_CLI" load --input <(
-    "$TAR" --cd "$RUNFILES_DIR/{{workspace_name}}" --create --no-xattr --no-mac-metadata @- <<< "$mtree_contents"
-)
+"$TAR" --cd "$RUNFILES_DIR/{{workspace_name}}" --create --no-xattr --no-mac-metadata @- <<< "$mtree_contents" | \
+    "$CONTAINER_CLI" load


### PR DESCRIPTION
Older versions of Podman appear to handle loading a tarball differently depending upon with the input is /dev/stdin or not. In particular:

    podman load --input <(cat foo.tar)

raises an error, while:

    cat foo.tar | podman load

works without error. (Podman loads from stdin if no --input is specified.)

This enables support for podman v3.4.4 included in Ubuntu 22.04.

fixes #711