### PR TITLE
Set `created` date based on `org.opencontainers.image.created` annotation

### DIFF
--- a/e2e/smoke/BUILD.bazel
+++ b/e2e/smoke/BUILD.bazel
@@ -19,7 +19,7 @@ expand_template(
 # SMOKE TEST: oci_image
 oci_image(
     name = "image",
-    annotations = ":annotations.txt",
+    annotations = ":annotations",
     base = "@distroless_base",
     cmd = [
         "--arg1",

--- a/e2e/smoke/BUILD.bazel
+++ b/e2e/smoke/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@aspect_bazel_lib//lib:diff_test.bzl", "diff_test")
 load("@aspect_bazel_lib//lib:testing.bzl", "assert_json_matches")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
@@ -11,8 +12,8 @@ load("@aspect_bazel_lib//lib:expand_template.bzl", "expand_template")
 expand_template(
     name = "annotations",
     out = "annotations.txt",
-    stamp_substitutions = {"1970-01-01T00:00:00Z": "{{BUILD_ISO8601}}"},
-    template = "annotations.txt.template",
+    stamp_substitutions = {"2000-01-01T01:02:03Z": "{{BUILD_ISO8601}}"},
+    template = ["org.opencontainers.image.created=2000-01-01T01:02:03Z"],
 )
 
 # SMOKE TEST: oci_image
@@ -72,6 +73,19 @@ assert_json_matches(
     file1 = ":tar_manifest",
     file2 = ":expected_RepoTags",
     filter1 = ".[0].RepoTags",
+)
+
+genrule(
+    name = "docker_created",
+    srcs = [":tarball.tar"],
+    outs = ["docker_created.txt"],
+    cmd = "docker load -i $(location :tarball.tar) && docker inspect --format='{{{{.Created}}}}' {} > $@".format(tags[0]),
+)
+
+diff_test(
+    name = "test_created",
+    file1 = ":docker_created",
+    file2 = "expected_created.txt",
 )
 
 # SMOKE TEST: oci_image from an external repo

--- a/e2e/smoke/BUILD.bazel
+++ b/e2e/smoke/BUILD.bazel
@@ -3,10 +3,22 @@ load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
+load("@aspect_bazel_lib//lib:expand_template.bzl", "expand_template")
+
+# An example stamping annotations
+# Run this using `bazel run :load --stamp --workspace_status_command=./workspace_status_command.sh`
+# to see the `docker inspect --format='{{.Created}}' my/image:latest` print the image build date.
+expand_template(
+    name = "annotations",
+    out = "annotations.txt",
+    stamp_substitutions = {"1970-01-01T00:00:00Z": "{{BUILD_ISO8601}}"},
+    template = "annotations.txt.template",
+)
 
 # SMOKE TEST: oci_image
 oci_image(
     name = "image",
+    annotations = ":annotations.txt",
     base = "@distroless_base",
     cmd = [
         "--arg1",

--- a/e2e/smoke/workspace_status.sh
+++ b/e2e/smoke/workspace_status.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+BUILD_TIMESTAMP=${BUILD_TIMESTAMP:-$(date +%s)}
+BUILD_ISO8601=$(date -u -r "$BUILD_TIMESTAMP" +"%Y-%m-%dT%H:%M:%SZ")
+echo "BUILD_ISO8601 $BUILD_ISO8601"

--- a/oci/private/image.sh
+++ b/oci/private/image.sh
@@ -182,10 +182,10 @@ for ARG in "$@"; do
       update_manifest
 
     created_date="$(jq -r -n \
-        --arg created_key "${OPENCONTAINERS_CREATED_KEY}" \
-        --arg default_created_date "${DEFAULT_CREATED_DATE}" \
-        --rawfile annotations "${ARG#--annotations=}" \
-        '([$annotations | split("\n") | .[] | select(. != "") | split("=") | {key: .[0], value: .[1]}]) | map(select(.key==$created_key)) | first | .value // $default_created_date')"
+      --arg created_key "${OPENCONTAINERS_CREATED_KEY}" \
+      --arg default_created_date "${DEFAULT_CREATED_DATE}" \
+      --rawfile annotations "${ARG#--annotations=}" \
+      '([$annotations | split("\n") | .[] | select(. != "") | split("=") | {key: .[0], value: .[1]}]) | map(select(.key==$created_key)) | first | .value // $default_created_date')"
     get_config | jq --arg created_date "${created_date}" '.created = $created_date' | update_config >/dev/null
     ;;
   *)


### PR DESCRIPTION
Fixes #661 

# Why?

Doing a `docker inspect --format='{{.Created}}' my/image:latest` on an
image built with `oci_image` previously always returned the static
beginning of the unix timestamp (1. January 1970 00:00:00). To be more
precise, that's what it returns for images that are built "from
scratch". When an image is built on a base, then the created date is set
to the created date of the base image.

Both are fine strategies for reproducible builds, but in stamped builds
that are eventually shipped/deployed, you probably want to set that time
to the actual build time.

Stamping is already supported, e.g. by setting annotations, which can
use stamp variables through a workspace status command.

Furthermore, the OCI image spec already [defines an annotation](https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys) to describe the time and date the image was built.
Which of course, when `docker load -i mytarball.tar` is dutifully
ignored by docker.

We can leverage this and, if the OCI annotation is provided, also set
the created date to that same value. When it isn't, we simply fall back
to the old behaviour.

### Further thoughts

I of course debated

* adding a separate attribute `created` on the `oci_image` rule itself
* Documentation? We could add some explanation to the `oci_image` macro, but it already talks about annotations and somehow I feel like a mention of a specific label and creation date is too detail-oriented? Happy to change my mind ...
* not caring about docker. I have to check my specific use case again, but it might be that AWS ECR metadata APIs already interpret read the OCI annotation over the `created` field? Not sure ...
* How do we add a test for this? Seems the `image.sh` script itself is not tested in isolation so far. I have various local incarnations but eventually landed on the diff test using the docker CLI client. Seems like that's not available on CI though 🤷🏽 