### PR TITLE
refactor: remote_tags unnecessarily restrictive

### DIFF
--- a/docs/push.md
+++ b/docs/push.md
@@ -155,7 +155,7 @@ multirun(
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="oci_push_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="oci_push_rule-image"></a>image |  Label to an oci_image or oci_image_index   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
-| <a id="oci_push_rule-remote_tags"></a>remote_tags |  a .txt file containing tags, one per line. These are passed to [`crane tag`]( https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_tag.md)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="oci_push_rule-remote_tags"></a>remote_tags |  a text file containing tags, one per line. These are passed to [`crane tag`]( https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_tag.md)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="oci_push_rule-repository"></a>repository |  Repository URL where the image will be signed at, e.g.: `index.docker.io/<user>/image`. Digests and tags are not allowed.   | String | optional |  `""`  |
 | <a id="oci_push_rule-repository_file"></a>repository_file |  The same as 'repository' but in a file. This allows pushing to different repositories based on stamping.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 

--- a/oci/private/push.bzl
+++ b/oci/private/push.bzl
@@ -174,11 +174,11 @@ _attrs = {
     ),
     "remote_tags": attr.label(
         doc = """\
-        a .txt file containing tags, one per line.
+        a text file containing tags, one per line.
         These are passed to [`crane tag`](
         https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_tag.md)
         """,
-        allow_single_file = [".txt"],
+        allow_single_file = True,
     ),
     "_allowlist_function_transition": attr.label(
         default = "@bazel_tools//tools/allowlists/function_transition_allowlist",


### PR DESCRIPTION
`oci_push#remote_tags` is too restrictive about what the file extension should even thought it doesn't really care what it is as long as it is a valid text file.