### PR TITLE
Fix macOS CI after #724

### DIFF
--- a/e2e/smoke/.bazelrc
+++ b/e2e/smoke/.bazelrc
@@ -1,1 +1,3 @@
-test --test_env=DOCKER_HOST
+common --enable_platform_specific_config
+test:macos --action_env=DOCKER_HOST
+test  --test_env=DOCKER_HOST


### PR DESCRIPTION
https://github.com/bazel-contrib/rules_oci/actions/runs/11564798863/job/32190695142

```
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
```

In #724 it looks like I broke macos CI because that particular step is not run as part of the PR builds. I introduced a genrule which requires access to the docker daemon, while previously it was only used in test rules.

Adding the env var to the docker host to the action graph should maybe fix this?