### PR TITLE
Handle not-logged-in public repos with credsStore

### DIFF
--- a/oci/private/authn.bzl
+++ b/oci/private/authn.bzl
@@ -126,6 +126,11 @@ exec "docker-credential-{}" get <<< "$1" """.format(helper_name),
 
     response = json.decode(result.stdout)
 
+    # If the username and secret are empty, the user does not have a login.
+    # Returning {} avoids sending invalid Basic auth headers that result in 401's
+    if response["Username"] == "" and response["Secret"] == "":
+        return {}
+
     return {
         "type": "basic",
         "login": response["Username"],


### PR DESCRIPTION
Tested with a docker config that only has a `credsStore` but without an account for `index.docker.io`. Previously, this would result in a 401 when requesting the realm URL, but now it succeeds.

```json
{
        "auths": {},
        "credsStore": "devpod"
}
```