### PR TITLE
feat: Possible to skip cosign toolchains registration

### DIFF
--- a/cosign/repositories.bzl
+++ b/cosign/repositories.bzl
@@ -38,7 +38,7 @@ cosign_repositories = repository_rule(
 )
 
 # Wrapper macro around everything above, this is the primary API
-def cosign_register_toolchains(name):
+def cosign_register_toolchains(name, register = True):
     """Convenience macro for users which does typical setup.
 
     - create a repository for each built-in platform like "cosign_linux_amd64" -
@@ -57,7 +57,8 @@ def cosign_register_toolchains(name):
             platform = platform,
             cosign_version = COSIGN_VERSIONS.keys()[0],
         )
-        native.register_toolchains("@{}//:{}_toolchain".format(toolchain_name, platform))
+        if register:
+            native.register_toolchains("@{}//:{}_toolchain".format(toolchain_name, platform))
 
     toolchains_repo(
         name = toolchain_name,


### PR DESCRIPTION
Adding this flag to make it possible to use in bzlmod. This approach aligns with https://github.com/bazel-contrib/rules_oci/blob/a195e365b8653139bef7f6bbb3e7b00b4eabd024/oci/repositories.bzl#L97