### PR TITLE
feat: Transition oci_image_index into a macro with additional [name].digest target

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -18,7 +18,11 @@ stardoc_with_diff_test(
 
 stardoc_with_diff_test(
     name = "image_index",
-    bzl_library_target = "//oci/private:image_index",
+    bzl_library_target = "//oci:defs",
+    symbol_names = [
+        "oci_image_index_rule",
+        "oci_image_index",
+    ],
 )
 
 stardoc_with_diff_test(

--- a/docs/image_index.md
+++ b/docs/image_index.md
@@ -1,13 +1,17 @@
 <!-- Generated with Stardoc: http://skydoc.bazel.build -->
 
-Implementation details for oci_image_index rule
+To load these rules, add this to the top of your `BUILD` file:
 
-<a id="oci_image_index"></a>
+```starlark
+load("@rules_oci//oci:defs.bzl", ...)
+```
 
-## oci_image_index
+<a id="oci_image_index_rule"></a>
+
+## oci_image_index_rule
 
 <pre>
-oci_image_index(<a href="#oci_image_index-name">name</a>, <a href="#oci_image_index-images">images</a>)
+oci_image_index_rule(<a href="#oci_image_index_rule-name">name</a>, <a href="#oci_image_index_rule-images">images</a>)
 </pre>
 
 Build a multi-architecture OCI compatible container image.
@@ -39,7 +43,30 @@ oci_image_index(
 
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="oci_image_index-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="oci_image_index-images"></a>images |  List of labels to oci_image targets.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
+| <a id="oci_image_index_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="oci_image_index_rule-images"></a>images |  List of labels to oci_image targets.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
+
+
+<a id="oci_image_index"></a>
+
+## oci_image_index
+
+<pre>
+oci_image_index(<a href="#oci_image_index-name">name</a>, <a href="#oci_image_index-kwargs">kwargs</a>)
+</pre>
+
+Macro wrapper around [oci_image_index_rule](#oci_image_index_rule).
+
+Produces a target `[name].digest`, whose default output is a file containing the sha256 digest of the resulting image.
+This is the same output as for the `oci_image` macro.
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="oci_image_index-name"></a>name |  name of resulting oci_image_index_rule   |  none |
+| <a id="oci_image_index-kwargs"></a>kwargs |  other named arguments to [oci_image_index_rule](#oci_image_index_rule) and [common rule attributes](https://bazel.build/reference/be/common-definitions#common-attributes).   |  none |
 
 

--- a/examples/multi_architecture_image/BUILD.bazel
+++ b/examples/multi_architecture_image/BUILD.bazel
@@ -32,16 +32,8 @@ oci_image_index(
     ],
 )
 
-genrule(
-    name = "hash",
-    srcs = [":index"],
-    outs = ["sha256.sum"],
-    cmd = "$(JQ_BIN) -r '.manifests[0].digest' $(location :index)/index.json > $@",
-    toolchains = ["@jq_toolchains//:resolved_toolchain"],
-)
-
 assert_contains(
     name = "check_digest",
-    actual = ":hash",
+    actual = ":index.digest",
     expected = "sha256:a2b8ae94672721788b67874f27cf3574fada3ccccc69f483bcb43de653573fe0",
 )


### PR DESCRIPTION
Related issue #735.

Since `oci_image_index` was a rule directly exposed in `defs.bzl`, I had to introduce a new macro. I opted to make it in the same way as `oci_index`, by using the `oci_index_image` name for the macro, while renaming the existing rule as `oci_index_image_rule`. I'm not sure if this kind of change would be considered a breaking change or not.

Please review if you find this kind of change from a rule to a macro acceptable or not. If not, I can expose this new macro with a different name (if you have any suggestions on what name to use, I'm all ears 😅) keeping the old rule unchanged.