### PR TITLE
chore: upgrade regctl

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,9 +6,6 @@ build --incompatible_strict_action_env
 build --nolegacy_external_runfiles
 common --test_env=DOCKER_HOST --action_env=DOCKER_HOST --repo_env=DOCKER_HOST
 
-# Prepare for Bazel 8
-common --incompatible_use_plus_in_repo_names
-
 # Disable bzlmod lockfile
 common --lockfile_mode=off
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -6,6 +6,9 @@ build --incompatible_strict_action_env
 build --nolegacy_external_runfiles
 common --test_env=DOCKER_HOST --action_env=DOCKER_HOST --repo_env=DOCKER_HOST
 
+# Prepare for Bazel 8
+common --incompatible_use_plus_in_repo_names
+
 # Disable bzlmod lockfile
 common --lockfile_mode=off
 

--- a/.bazelversion
+++ b/.bazelversion
@@ -1,4 +1,4 @@
-7.1.1
+7.4.1
 
 # The first line of this file is used by Bazelisk and Bazel to be sure
 # the right version of Bazel is used to build and test this repo.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -138,9 +138,6 @@ jobs:
 
       - name: bazel test //...
         working-directory: ${{ matrix.folder }}
-        env:
-          # Bazelisk will download bazel to here, ensure it is cached between runs.
-          XDG_CACHE_HOME: ~/.cache/bazel-repo
         run: |
           bazel \
           --bazelrc=$GITHUB_WORKSPACE/.github/workflows/ci.bazelrc \

--- a/oci/private/versions.bzl
+++ b/oci/private/versions.bzl
@@ -18,6 +18,15 @@ CRANE_VERSIONS = {
 }
 
 REGCTL_VERSIONS = {
+    "v0.8.0": {
+        "darwin-amd64": "sha256-RHuyX4G1Sk1plj0spLmK476+Jljk/fqh3oOAvCzCwuw=",
+        "darwin-arm64": "sha256-jUzYxiyhtoeh4clFm8kdLfkzmHkk65+YksB/eBJAqJU=",
+        "linux-amd64": "sha256-Inbt7loeXLibtORI5dAjVkrNbYSlQZzJL/Ji2F37jpo=",
+        "linux-arm64": "sha256-6cXL+dpQUoQgkcNiG0k+piHw/+G3KqdrYLa1/haquN4=",
+        "linux-ppc64le": "sha256-0w0qwWCpx97Ew2quFz9IBuHi4ZwoSj41oFLxco2/v3g=",
+        "linux-s390x": "sha256-mtTFWhB0BcWANbF3RSdk12pVcwtkg7RKkC7mwyHyV5U=",
+        "windows-amd64": "sha256-OaMBqF3M/kedW1bVI4GLuwDW3jzjT8Ujn7CtPkT+inc=",
+    },
     "v0.7.0": {
         "darwin-amd64": "sha256-QH7AeVJi/Ehn09yCVDq1qWvO6VBwquAFV6uPQyX5DDQ=",
         "darwin-arm64": "sha256-QTr9nUPdjknzYTnOgfKG32C2id3aPngG82V7zLOWQL8=",

--- a/oci/repositories.bzl
+++ b/oci/repositories.bzl
@@ -60,7 +60,7 @@ regctl_toolchain(
     regctl = "regctl{ext}",
 )
 """
-REGCTL_VERSION = "v0.7.0"
+REGCTL_VERSION = "v0.8.0"
 
 REGCTL_PLATFORMS = {
     name: platform


### PR DESCRIPTION
Note, I would have added the `--incompatible_use_plus_in_repo_names` flag to `.bazelrc` in this PR, but that would break our Bazel 6 test matrix. We'll get that flag soon enough when we add Bazel 8 testing.

Fixes #738