### PR TITLE
use transition to resolve correct tar in oci_load

### DIFF
--- a/oci/private/load.bzl
+++ b/oci/private/load.bzl
@@ -131,12 +131,19 @@ attrs = {
     "_tarball_sh": attr.label(allow_single_file = True, default = "//oci/private:tarball.sh.tpl"),
     "_runfiles": attr.label(default = "@bazel_tools//tools/bash/runfiles"),
     "_windows_constraint": attr.label(default = "@platforms//os:windows"),
+    "_allowlist_function_transition": attr.label(
+        default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+    ),
+    "_tar": attr.label(
+        cfg = util.transition_to_target,
+        default = "@bsd_tar_toolchains//:resolved_toolchain",
+    ),
 }
 
 def _load_impl(ctx):
     jq = ctx.toolchains["@aspect_bazel_lib//lib:jq_toolchain_type"]
     coreutils = ctx.toolchains["@aspect_bazel_lib//lib:coreutils_toolchain_type"]
-    bsdtar = ctx.toolchains["@aspect_bazel_lib//lib:tar_toolchain_type"]
+    bsdtar = ctx.attr._tar[0][platform_common.ToolchainInfo]
 
     image = ctx.file.image
     repo_tags = ctx.file.repo_tags

--- a/oci/private/push.bzl
+++ b/oci/private/push.bzl
@@ -137,23 +137,6 @@ multirun(
 [rules_multirun]: https://github.com/keith/rules_multirun
 """
 
-# Helper rule for ensuring that the crane and yq toolchains are actually
-# resolved for the architecture we are targeting.
-def _transition_to_target_impl(settings, _attr):
-    return {
-        # String conversion is needed to prevent a crash with Bazel 6.x.
-        "//command_line_option:extra_execution_platforms": [
-            str(platform)
-            for platform in settings["//command_line_option:platforms"]
-        ],
-    }
-
-_transition_to_target = transition(
-    implementation = _transition_to_target_impl,
-    inputs = ["//command_line_option:platforms"],
-    outputs = ["//command_line_option:extra_execution_platforms"],
-)
-
 _attrs = {
     "image": attr.label(
         allow_single_file = True,
@@ -184,7 +167,7 @@ _attrs = {
         default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
     ),
     "_crane": attr.label(
-        cfg = _transition_to_target,
+        cfg = util.transition_to_target,
         default = "@oci_crane_toolchains//:current_toolchain",
     ),
     "_push_sh_tpl": attr.label(
@@ -193,7 +176,7 @@ _attrs = {
     ),
     "_windows_constraint": attr.label(default = "@platforms//os:windows"),
     "_jq": attr.label(
-        cfg = _transition_to_target,
+        cfg = util.transition_to_target,
         default = "@jq_toolchains//:resolved_toolchain",
     ),
 }

--- a/oci/private/util.bzl
+++ b/oci/private/util.bzl
@@ -224,6 +224,23 @@ def _platform_triplet(platform_str):
         architecture, _, variant = architecture.partition("/")
     return os, architecture, variant
 
+# Helper rule for ensuring that the crane and yq toolchains are actually
+# resolved for the architecture we are targeting.
+def _transition_to_target_impl(settings, _attr):
+    return {
+        # String conversion is needed to prevent a crash with Bazel 6.x.
+        "//command_line_option:extra_execution_platforms": [
+            str(platform)
+            for platform in settings["//command_line_option:platforms"]
+        ],
+    }
+
+_transition_to_target = transition(
+    implementation = _transition_to_target_impl,
+    inputs = ["//command_line_option:platforms"],
+    outputs = ["//command_line_option:extra_execution_platforms"],
+)
+
 util = struct(
     parse_image = _parse_image,
     sha256 = _sha256,
@@ -234,4 +251,5 @@ util = struct(
     build_manifest_json = _build_manifest_json,
     assert_crane_version_at_least = _assert_crane_version_at_least,
     platform_triplet = _platform_triplet,
+    transition_to_target = _transition_to_target,
 )


### PR DESCRIPTION
This is similar to and based on https://github.com/bazel-contrib/rules_oci/pull/590

We're building `oci_load` targets with RBE on linux machines, and the tar in the load script fails to execute on macos hosts.