### PR TITLE
fix: drop embedded config data from manifest image

### DIFF
--- a/oci/private/image.sh
+++ b/oci/private/image.sh
@@ -57,7 +57,7 @@ function update_config() {
   local config=
   config="$(coreutils cat -)"
   digest="$(echo -n "$config" | regctl blob put "$REF")"
-  get_manifest | jq '.config.digest = $digest | .config.size = $size' --arg digest "$digest" --argjson size "${#config}" | update_manifest >/dev/null
+  get_manifest | jq '.config.digest = $digest | .config.size = $size | del(.config.data)' --arg digest "$digest" --argjson size "${#config}" | update_manifest >/dev/null
   echo "$digest"
 }
 

--- a/oci/private/image.sh
+++ b/oci/private/image.sh
@@ -57,6 +57,7 @@ function update_config() {
   local config=
   config="$(coreutils cat -)"
   digest="$(echo -n "$config" | regctl blob put "$REF")"
+  # The embedded .config.data must be kept up to date or dropped. Making the optimal choice is subtle; dropping is always at least correct.
   get_manifest | jq '.config.digest = $digest | .config.size = $size | del(.config.data)' --arg digest "$digest" --argjson size "${#config}" | update_manifest >/dev/null
   echo "$digest"
 }


### PR DESCRIPTION
The [OCI spec](https://github.com/opencontainers/image-spec/blob/main/descriptor.md#properties) provides a `data` field in order to embed a copy of an image's config directly into that image's manifest:

> data string
>
> This OPTIONAL property contains an embedded representation of the referenced content. Values MUST conform to the Base 64 encoding, as defined in RFC 4648. The decoded data MUST be identical to the referenced content and SHOULD be verified against the digest and size fields by content consumers. See Embedded Content for when this is appropriate.

This is [intended as an optimization](https://github.com/opencontainers/image-spec/blob/main/descriptor.md#embedded-content), in order to reduce the number of network round-trips incurred to pull a container from a remote repository.

However, as highlighted in the release announcement for the new [`data` field](https://opencontainers.org/posts/blog/2024-03-13-image-and-distribution-1-1/#data-field), the contexts in which an embedded config is beneficial can be a subtle determination. Further, in the same announcement, the spec clarified that registry implementations usually enforce a [maximum size](https://opencontainers.org/posts/blog/2024-03-13-image-and-distribution-1-1/#manifest-maximum-size) on manifests, an obscure limit which incautious use of the `data` field can trigger.

Given the trade-offs, dropping any embedded data (e.g. that might have been propagated from a base image) seems the preferable option. The alternative — updating embedded data to match the config on every change, as proposed by https://github.com/bazel-contrib/rules_oci/pull/757 — is less universally correct and only sometimes more performant. Either option would fix https://github.com/bazel-contrib/rules_oci/issues/756 .