### PR TITLE
Add --use --bootstrap to dockerfile builder example

### DIFF
--- a/examples/dockerfile/buildx.bzl
+++ b/examples/dockerfile/buildx.bzl
@@ -28,7 +28,16 @@ def _impl_configure_buildx(rctx):
 
         r = rctx.execute([buildx, "ls"])
         if not builder_name in r.stdout:
-            r = rctx.execute([buildx, "create", "--name", builder_name, "--driver", "docker-container"])
+            r = rctx.execute([
+                buildx,
+                "create",
+                "--name",
+                builder_name,
+                "--driver",
+                "docker-container",
+                "--use",
+                "--bootstrap",
+            ])
             if r.return_code != 0:
                 fail("Failed to create buildx driver %s: \nSTDERR:\n%s\nsSTDOUT:\n%s" % (builder_name, r.stderr, r.stdout))
         else:


### PR DESCRIPTION
We've been using https://github.com/bazel-contrib/rules_oci/tree/main/examples/dockerfile for a while now and its been working well.

In our repo, I added another rule that also needed to use the `buildx` binary, but it seems that the rule has a race condition. This wasn't happening on my Mac but it was happening in our CI machines running on Linux.

Example error:
```
#0 building with "builder-docker" instance using docker-container driver00:27
#1 [internal] booting buildkit00:27
#1 pulling image moby/buildkit:buildx-stable-100:27
#1 pulling image moby/buildkit:buildx-stable-1 5.4s done00:27
#1 creating container buildx_buildkit_builder-docker000:27
#1 creating container buildx_buildkit_builder-docker0 14.4s done00:27
#1 ERROR: Error response from daemon: No such container: buildx_buildkit_builder-docker0
```

I think it was caused by multiple actions trying to startup the builder container simultaneously. The added flags ensure the container starts up as part of the repository rule, so the actions don't need to wait.