### PR TITLE
refactor: publish better buildx api

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,1 +1,2 @@
 e2e
+examples/dockerfile

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,6 +64,7 @@ jobs:
           - e2e/wasm
           - e2e/smoke
           - e2e/assertion
+          - examples/dockerfile
 
         bzlmodEnabled: [true, false]
         exclude:
@@ -75,6 +76,10 @@ jobs:
           - os: macos-13
             bazelversion: 6.4.0
           - folder: .
+            bazelversion: 6.4.0
+          - folder: examples/dockerfile
+            bzlmodEnabled: false
+          - folder: examples/dockerfile
             bazelversion: 6.4.0
           # e2e/assertion is bzlmod only but it has test for both cases.
           - folder: e2e/assertion

--- a/examples/dockerfile/BUILD.bazel
+++ b/examples/dockerfile/BUILD.bazel
@@ -1,78 +1,47 @@
-load("@aspect_bazel_lib//lib:run_binary.bzl", "run_binary")
-load("@configure_buildx//:defs.bzl", "BUILDER_NAME", "TARGET_COMPATIBLE_WITH")
-load("@rules_oci//oci:defs.bzl", "oci_image")
-load("//examples:assert.bzl", "assert_oci_config", "assert_oci_image_command")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@buildx//:defs.bzl", "buildx", "context")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
 
-# docker buildx create --name container --driver=docker-container
-run_binary(
-    name = "base",
-    srcs = ["Dockerfile"] + glob(["src/*"]),
-    args = [
-        "build",
-        "./examples/dockerfile",
-        "--builder",
-        BUILDER_NAME,
-        "--output=type=oci,tar=false,dest=$@",
+buildx(
+    name = "base_image",
+    build_context = [
+        # replaces FROM python:3.11.9-bullseye with @ubuntu from oci_pull
+        context.oci_layout(
+            "python:3.11.9-bullseye",
+            "@python_3_11_9-bullseye",
+        ),
+        # make lib1 available as COPY --from=lib1 in the dockerfile
+        context.sources(
+            "lib1",
+            ["//libs/lib1:lib1"],
+            override_path = "libs/lib1",
+        ),
+        context.sources(
+            "bins_hi",
+            ["//bins/hi:hi"],
+            override_path = "$(BINDIR)/bins/hi",
+        ),
+        context.sources(
+            "root",
+            glob(["src/*"]),
+            override_path = "src",
+        ),
     ],
-    execution_requirements = {"local": "1"},
-    mnemonic = "BuildDocker",
-    out_dirs = ["base"],
-    target_compatible_with = TARGET_COMPATIBLE_WITH,
-    tool = "@multitool//tools/buildx",
+    dockerfile = ":Dockerfile",
 )
 
 oci_image(
     name = "image",
-    base = ":base",
+    base = ":base_image",
 )
 
-assert_oci_config(
-    name = "assert_metadata",
-    cmd_eq = ["/app/say.py"],
-    entrypoint_eq = None,
+oci_load(
+    name = "load",
     image = ":image",
+    repo_tags = ["example:latest"],
 )
 
-assert_oci_image_command(
-    name = "assert_jq_works",
-    args = [
-        "jq",
-        "--version",
-    ],
-    exit_code_eq = 0,
-    image = ":image",
-    output_eq = "jq-1.6\n",
-)
-
-assert_oci_image_command(
-    name = "assert_apt_lists_still_exist",
-    args = [
-        "file",
-        "/var/lib/apt/lists",
-    ],
-    exit_code_eq = 0,
-    image = ":image",
-    output_eq = "/var/lib/apt/lists: directory\n",
-)
-
-assert_oci_image_command(
-    name = "assert_cow_says_moo",
-    args = [
-        "python",
-        "/app/say.py",
-    ],
-    exit_code_eq = 0,
-    image = ":image",
-    output_eq = """\
-  ____
-| moo! |
-  ====
-    \\
-     \\
-       ^__^
-       (oo)\\_______
-       (__)\\       )\\/\\
-           ||----w |
-           ||     ||
-""",
+build_test(
+    name = "test",
+    targets = [":image"],
 )

--- a/examples/dockerfile/Dockerfile
+++ b/examples/dockerfile/Dockerfile
@@ -13,6 +13,10 @@ RUN apt-get -y update \
 
 RUN pip install cowsay
 
-COPY src /app
+COPY --from=root . /app
+
+COPY --from=bins_hi hi_/hi /usr/local/bin/hi
+
+ENTRYPOINT ["/usr/local/bin/python3"]
 
 CMD ["/app/say.py"]

--- a/examples/dockerfile/MODULE.bazel
+++ b/examples/dockerfile/MODULE.bazel
@@ -1,0 +1,30 @@
+"Dockerfile example using BuildX and OCI"
+
+module(name = "dockerfile")
+
+bazel_dep(name = "bazel_skylib", version = "1.5.0")
+bazel_dep(name = "aspect_bazel_lib", version = "2.7.2")
+bazel_dep(name = "rules_oci", version = "2.2.5")
+bazel_dep(name = "rules_go", version = "0.53.0")
+
+local_path_override(
+    module_name = "rules_oci",
+    path = "../..",
+)
+
+buildx = use_extension(":buildx.bzl", "buildx")
+buildx.toolchains()
+use_repo(buildx, "buildx")
+
+# Fetch the base image to be used for the build.
+oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
+oci.pull(
+    name = "python_3_11_9-bullseye",
+    digest = "sha256:64da8e5fd98057b05db01b49289b774e9fa3b81e87b4883079f6c31fb141b252",
+    image = "python:3.11.9-bullseye",
+    platforms = [
+        "linux/arm64/v8",
+        "linux/amd64",
+    ],
+)
+use_repo(oci, "python_3_11_9-bullseye", "python_3_11_9-bullseye_linux_amd64", "python_3_11_9-bullseye_linux_arm64_v8")

--- a/examples/dockerfile/README.md
+++ b/examples/dockerfile/README.md
@@ -1,12 +1,17 @@
 # Dockerfile + rules_oci
 
-STOP before committing this atrocity. Here's some good reasons why you should not do what we have done here.
+Here's some good reasons why you should not consider Dockerfiles
 
-- Dockerfiles are fundamentally non-reproducible
-- Reproducible builds are important for Bazel, Dockerfiles will lead to poor cache hits.
+- It depends on a functioning container runtime which is not always available, for example on RBE.
+- Dockerfiles are fundamentally non-reproducible, you could hack around this fact, but you will always be fighting it.
+- Reproducible builds are important for Bazel, Dockerfiles might become the reason for slower CI.
 - `RUN` instruction is a perfect foot-gun for non-reprocubile builds, a simple command `RUN apt-get install curl` is non-hermetic by default.
-- Building the same Dockerfile one month apart will yield different results.
-- `FROM python:3.11.9-bullseye` is non-producible.
+- Building the same Dockerfile one month apart may yield different results for simple cases such as `FROM python:3.11.9-bullseye`.
+
+And some good reasons why you should
+
+- Easy to write, well understood by engineers as opposed to BUILD files.
+- Plenty of examples out there that makes it easy to find good patterns.
 
 # Resources
 
@@ -14,4 +19,5 @@ https://reproducible-builds.org/
 https://github.com/bazel-contrib/rules_oci/issues/35#issuecomment-1285954483
 https://github.com/bazel-contrib/rules_oci/blob/main/docs/compare_dockerfile.md
 https://github.com/moby/moby/issues/43124
+https://github.com/moby/buildkit/blob/master/docs/build-repro.md
 https://medium.com/nttlabs/bit-for-bit-reproducible-builds-with-dockerfile-7cc2b9faed9f

--- a/examples/dockerfile/bins/hi/BUILD.bazel
+++ b/examples/dockerfile/bins/hi/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@rules_go//go:def.bzl", "go_binary")
+
+go_binary(
+    name = "hi",
+    srcs = ["main.go"],
+    visibility = ["//visibility:public"],
+)

--- a/examples/dockerfile/bins/hi/main.go
+++ b/examples/dockerfile/bins/hi/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, Docker!")
+}

--- a/examples/dockerfile/buildx.bzl
+++ b/examples/dockerfile/buildx.bzl
@@ -1,6 +1,142 @@
 "repos for buildx"
 
 load("@aspect_bazel_lib//lib:repo_utils.bzl", "repo_utils")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+
+BUILDX_WORKAROUND = """
+def _oci_layout_buildx_workaround_impl(ctx):
+    '''workaround for buildx to accept oci-layout with lock file and ingest directory already created
+    See: https://github.com/docker/buildx/issues/2753https://github.com/docker/buildx/issues/2753#issuecomment-2436601290https://github.com/containerd/containerd/issues/10885https://github.com/docker/buildx/issues/2753#issuecomment-2436324404
+    '''
+    output = ctx.actions.declare_directory(ctx.label.name)
+    coreutils = ctx.toolchains["@aspect_bazel_lib//lib:coreutils_toolchain_type"].coreutils_info.bin
+    ctx.actions.run_shell(
+        outputs = [output],
+        inputs = [ctx.file.layout],
+        tools = [coreutils],
+        toolchain = "@aspect_bazel_lib//lib:coreutils_toolchain_type",
+        command = '''
+for blob in $($COREUTILS ls -1 -d "$LAYOUT/blobs/"*/*); do
+    relative_to_blobs="${blob#"$LAYOUT/blobs"}"
+    $COREUTILS mkdir -p "$OUTPUT/blobs/$($COREUTILS dirname "$relative_to_blobs")"
+    # Relative path from `output/blobs/sha256/` to `$blob`
+    relative="$($COREUTILS realpath --relative-to="$OUTPUT/blobs/sha256" "$blob" --no-symlinks)"
+    $COREUTILS ln -s "$relative" "$OUTPUT/blobs/$relative_to_blobs"
+done
+$COREUTILS cp --no-preserve=mode "$LAYOUT/oci-layout" "$OUTPUT/oci-layout"
+$COREUTILS cp --no-preserve=mode "$LAYOUT/index.json" "$OUTPUT/index.json"
+$COREUTILS touch "$OUTPUT/index.json.lock"
+$COREUTILS mkdir "$OUTPUT/ingest"
+$COREUTILS touch "$OUTPUT/ingest/.keep"
+        ''',
+        env = {
+            "COREUTILS": coreutils.path,
+            "OUTPUT": output.path,
+            "LAYOUT": ctx.file.layout.path,
+        },
+        mnemonic = "WorkaroundBuildX",
+    )
+    return DefaultInfo(
+        files = depset([output]),
+        runfiles = ctx.attr.layout[DefaultInfo].default_runfiles,
+    )
+
+oci_layout_buildx_workaround = rule(
+    implementation = _oci_layout_buildx_workaround_impl,
+    attrs = {
+        "layout": attr.label(allow_single_file = True),
+    },
+    toolchains = ["@aspect_bazel_lib//lib:coreutils_toolchain_type"],
+)
+"""
+
+BUILDX_RULE = """
+def buildx(name, dockerfile, path = ".", srcs = [], build_context = [], execution_requirements = {"local": "1"}, tags = ["manual"], visibility = []):
+    \"\"\"
+    Run BuildX to produce OCI base image using a Dockerfile. 
+
+    Args:
+        name: name of the target
+        dockerfile: label to the dockerfile to use for this build
+        path: path to build context where all will be relative to under Dockerfile
+        build_context: a dictionary for custom build contexes. See https://docs.docker.com/reference/cli/docker/buildx/build/#build-context
+        execution_requirements: execution requirements for the action, we recommend using local as BuildX wants to read files outside of the sandbox.
+        tags: tags for the target
+        visibility: visibility for the target
+    \"\"\"
+    if "requires-docker" not in tags:
+        tags = tags + ["requires-docker"]
+
+    context_args = []
+    context_srcs = []
+    for context in build_context:
+        context_srcs = context_srcs + context["srcs"]
+        context_args.append("--build-context={}={}".format(context["replace"], context["store"]))
+    
+
+    copy_file(
+        name = name + "_dockerfile",
+        src = dockerfile,
+        out = "Dockerfile." + name,
+    )
+
+
+    run_binary(
+        name = name,
+        srcs = [name + "_dockerfile"] + srcs + context_srcs,
+        args = [
+            "build",
+            path,
+            "--file",
+            "$(location {}_dockerfile)".format(name),
+            "--builder",
+            BUILDER_NAME,
+            "--output=type=oci,tar=false,dest=$@",
+            # Set the source date epoch to 0 for better reproducibility.
+            "--build-arg SOURCE_DATE_EPOCH=0",
+        ] + context_args,
+        execution_requirements =  execution_requirements,
+        mnemonic = "BuildX",
+        out_dirs = [name],
+        target_compatible_with = TARGET_COMPATIBLE_WITH,
+        tool = "@buildx//:buildx",
+        tags = tags,
+        visibility = visibility,
+    )
+
+"""
+
+BUILDX_CONTEXT_SYNTAX_SUGAR = """
+def context_oci_layout(replace, layout):
+    name = str(replace).replace("/", "_").replace(":", "_")
+    # TODO: remove once https://github.com/docker/buildx/issues/2753 is solved and set store to layout directly.
+    oci_layout_buildx_workaround(
+        name = name,
+        layout = layout,
+    )
+    return {
+        "replace": replace,
+        "store": "oci-layout://$(location %s)" % name,
+        "srcs": [name],
+    }
+
+
+def context_sources(replace, sources, override_path = None):
+    store = "$(location %s)" % sources
+    if override_path:
+        store = override_path
+        
+    return {
+        "replace": replace,
+        "store": store,
+        "srcs": sources,
+    }
+
+context = struct(
+    oci_layout = context_oci_layout,
+    sources = context_sources
+)
+"""
 
 def _impl_configure_buildx(rctx):
     has_docker = False
@@ -14,48 +150,100 @@ def _impl_configure_buildx(rctx):
     compatible_with = "[]"
     builder_name = "builder-docker"
     if has_docker:
-        # TODO(alex): a less hacky way for a repo rule to find this transitive repo label?
-        if repo_utils.platform(rctx) == "darwin_amd64":
-            multitool_label = "@@rules_multitool~~multitool~multitool.macos_x86_64//tools/buildx:macos_x86_64_executable"
-        elif repo_utils.platform(rctx) == "darwin_arm64":
-            multitool_label = "@@rules_multitool~~multitool~multitool.macos_arm64//tools/buildx:macos_arm64_executable"
-        elif repo_utils.platform(rctx) == "linux_amd64":
-            multitool_label = "@@rules_multitool~~multitool~multitool.linux_x86_64//tools/buildx:linux_x86_64_executable"
-        else:
-            fail("platform {} is not known", repo_utils.platform(rctx))
-
-        buildx = rctx.path(Label(multitool_label))
+        buildx = rctx.path(rctx.attr.buildx)
 
         r = rctx.execute([buildx, "ls"])
         if not builder_name in r.stdout:
-            r = rctx.execute([
-                buildx,
-                "create",
-                "--name",
-                builder_name,
-                "--driver",
-                "docker-container",
-                "--use",
-                "--bootstrap",
-            ])
+            r = rctx.execute([buildx, "create", "--name", builder_name, "--driver", "docker-container"])
             if r.return_code != 0:
                 fail("Failed to create buildx driver %s: \nSTDERR:\n%s\nsSTDOUT:\n%s" % (builder_name, r.stderr, r.stdout))
-        else:
-            # buildifier: disable=print
-            print("WARNING: BuildX driver `%s` already exists." % builder_name)
 
     else:
         compatible_with = '["@platforms//:incompatible"]'
 
     rctx.file("defs.bzl", """
 # Generated by configure_buildx.bzl
+load("@aspect_bazel_lib//lib:run_binary.bzl", "run_binary")
+load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
+
 TARGET_COMPATIBLE_WITH = %s
 BUILDER_NAME = "%s"
-""" % (compatible_with, builder_name))
-    rctx.file("BUILD.bazel", 'exports_files(["defs.bzl"])')
+
+%s
+%s
+%s
+""" % (compatible_with, builder_name, BUILDX_RULE, BUILDX_WORKAROUND, BUILDX_CONTEXT_SYNTAX_SUGAR))
+    rctx.file("BUILD.bazel", '''
+exports_files(["defs.bzl"])
+
+alias(
+    name = "buildx",
+    actual = select({}),
+    visibility = ["//visibility:public"]
+)
+'''.format({
+        rctx.attr.buildx_platforms[platform]: str(platform)
+        for platform in rctx.attr.buildx_platforms
+    }))
     pass
 
 configure_buildx = repository_rule(
     implementation = _impl_configure_buildx,
     local = True,
+    attrs = {
+        "buildx": attr.label(),
+        "buildx_platforms": attr.label_keyed_string_dict(),
+    },
+)
+
+toolchains = tag_class(attrs = {})
+
+def _oci_extension(module_ctx):
+    if len(module_ctx.modules) > 1 or len(module_ctx.modules[0].tags.toolchains) > 1:
+        fail("buildx.toolchains should be called from root module only.")
+
+    buildx_version = "0.22.0"
+
+    buildx_platforms = {
+        "linux-arm64": "6e9e455b5ec1c7ac708f2640a86c5cecce38c72e48acff6cb219dfdfa2dda781",
+        "linux-amd64": "805195386fba0cea5a1487cf0d47da82a145ea0a792bd3fb477583e2dbcdcc2f",
+        "darwin-arm64": "5898c338abb1f673107bc087997dc3cb63b4ea66d304ce4223472f57bd8d616e",
+        "darwin-amd64": "5221ad6b8acd2283f8fbbeebc79ae4b657e83519ca1c1e4cfbb9405230b3d933",
+    }
+
+    for platform in buildx_platforms:
+        http_file(
+            name = "buildx_%s" % platform,
+            urls = ["https://github.com/docker/buildx/releases/download/v{version}/buildx-v{version}.{platform}".format(version = buildx_version, platform = platform)],
+            sha256 = buildx_platforms[platform],
+            executable = True,
+        )
+
+    buildx_selects = {
+        "@buildx_linux-amd64//file": "@bazel_tools//src/conditions:linux_x86_64",
+        "@buildx_linux-arm64//file": "@bazel_tools//src/conditions:linux_aarch64",
+        "@buildx_darwin-amd64//file": "@bazel_tools//src/conditions:darwin_x86_64",
+        "@buildx_darwin-arm64//file": "@bazel_tools//src/conditions:darwin_arm64",
+    }
+
+    configure_buildx(
+        name = "buildx",
+        buildx = "@buildx_%s//file:downloaded" % repo_utils.platform(module_ctx).replace("_", "-"),
+        buildx_platforms = buildx_selects,
+    )
+
+    root_direct_dev_deps = []
+
+    root_direct_deps = ["buildx"]
+
+    return module_ctx.extension_metadata(
+        root_module_direct_deps = root_direct_deps,
+        root_module_direct_dev_deps = root_direct_dev_deps,
+    )
+
+buildx = module_extension(
+    implementation = _oci_extension,
+    tag_classes = {
+        "toolchains": toolchains,
+    },
 )

--- a/examples/dockerfile/buildx.bzl
+++ b/examples/dockerfile/buildx.bzl
@@ -154,7 +154,7 @@ def _impl_configure_buildx(rctx):
 
         r = rctx.execute([buildx, "ls"])
         if not builder_name in r.stdout:
-            r = rctx.execute([buildx, "create", "--name", builder_name, "--driver", "docker-container"])
+            r = rctx.execute([buildx, "create", "--name", builder_name, "--driver", "docker-container", "--use", "--bootstrap"])
             if r.return_code != 0:
                 fail("Failed to create buildx driver %s: \nSTDERR:\n%s\nsSTDOUT:\n%s" % (builder_name, r.stderr, r.stdout))
 

--- a/examples/dockerfile/libs/lib1/BUILD.bazel
+++ b/examples/dockerfile/libs/lib1/BUILD.bazel
@@ -1,0 +1,5 @@
+filegroup(
+    name = "lib1",
+    srcs = glob(["*.py"]),
+    visibility = ["//visibility:public"],
+)

--- a/examples/dockerfile/libs/lib1/lib.py
+++ b/examples/dockerfile/libs/lib1/lib.py
@@ -1,0 +1,2 @@
+def say_hi():
+    print("Hello from lib1!")

--- a/fetch.bzl
+++ b/fetch.bzl
@@ -7,7 +7,6 @@ by writing them to a generated macro in a .bzl file.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@rules_oci//oci:pull.bzl", "oci_pull")
 load("//examples:setup_assertion_repos.bzl", "configure_docker")
-load("//examples/dockerfile:buildx.bzl", "configure_buildx")
 
 def fetch_images():
     "fetch external images"
@@ -242,9 +241,6 @@ def fetch_test_repos():
         build_file = "//examples/assertion/attest_external:BUILD.template",
         path = "examples/assertion/attest_external/workspace",
     )
-
-    # Setup buildx
-    configure_buildx(name = "configure_buildx")
 
     # Setup steps for docker testing
     configure_docker(name = "docker_configure")


### PR DESCRIPTION
For a long time we had dockerfile example but its DX was never good, this updates our  examples/dockerfile to be standalone and publishes the api with better DX that we created for somebody else. 


