### PR TITLE
example: use docker tarball as base image

### DIFF
--- a/examples/tarball_as_base/BUILD.bazel
+++ b/examples/tarball_as_base/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@aspect_bazel_lib//lib:run_binary.bzl", "run_binary")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
+
+filegroup(
+    name = "regctl",
+    srcs = ["@oci_regctl_toolchains//:current_toolchain"],
+)
+
+run_binary(
+    name = "base",
+    srcs = ["tarball.tar"],
+    args = [
+        "image",
+        "import",
+        "ocidir://$@",
+        "$(location :tarball.tar)",
+    ],
+    execution_requirements = {"local": "1"},
+    mnemonic = "ExtractTarball",
+    out_dirs = ["base"],
+    tool = ":regctl",
+)
+
+oci_image(
+    name = "image",
+    base = ":base",
+)
+
+oci_load(
+    name = "load",
+    image = ":image",
+    repo_tags = ["example:latest"],
+)

--- a/examples/tarball_as_base/BUILD.bazel
+++ b/examples/tarball_as_base/BUILD.bazel
@@ -1,11 +1,22 @@
 load("@aspect_bazel_lib//lib:run_binary.bzl", "run_binary")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
 
+# Pluck out the regctl tool from the toolchain.
 filegroup(
     name = "regctl",
     srcs = ["@oci_regctl_toolchains//:current_toolchain"],
 )
 
+# This run_binary rule extracts the tarball into an oci-layout directory using
+# the regctl tool that we use internally.
+# Output will look like this:
+#
+#  ├── blobs
+#  │   ├── sha256
+#  │   │   ├── 0xdeadbeef
+#  ├── index.json
+#  └── oci-layout
+# that can be used as a base for the oci_image rule.
 run_binary(
     name = "base",
     srcs = ["tarball.tar"],
@@ -21,11 +32,13 @@ run_binary(
     tool = ":regctl",
 )
 
+# Use the tarball as a base for the oci_image rule.
 oci_image(
     name = "image",
     base = ":base",
 )
 
+# And use this target load the resulting image into the local docker daemon for testing.
 oci_load(
     name = "load",
     image = ":image",


### PR DESCRIPTION
Adds an example for using a docker tarball as a base image to oci_image. In 1.x version of rules_oci this worked by accident where passing a tarball to the base attribute of oci_image would extract the tarball and use it as the base image but in 2.x this stopped working because we actually started asserting that the base image was in fact an oci-layout. 

Users are required to register the regctl toolchain in their MODULE.bazel if bzlmod is in use. 

```
oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
oci.toolchains()
use_repo(oci, "oci_regctl_toolchains")
```

Closes https://github.com/bazel-contrib/rules_oci/issues/700