### PR TITLE
image_index.sh.tpl: use "dirname" from COREUTILS

### DIFF
--- a/oci/private/image_index.sh.tpl
+++ b/oci/private/image_index.sh.tpl
@@ -35,7 +35,7 @@ function copy_blob() {
     local output_path="$2"
     local blob_image_relative_path="$3"
     local dest_path="${output_path}/${blob_image_relative_path}"
-    mkdirp "$(dirname "${dest_path}")"
+    mkdirp "$("${COREUTILS}" dirname "${dest_path}")"
     "${COREUTILS}" cp --no-preserve=mode "${image_path}/${blob_image_relative_path}" "${dest_path}"
 }
 


### PR DESCRIPTION
`dirname` is part of `coreutils` and may be unavailable on remote executors environments, let's use hermetic version