### PR TITLE
tarball.sh.tpl: add nlink=1 to mspec

### DIFF
--- a/oci/private/tarball.sh.tpl
+++ b/oci/private/tarball.sh.tpl
@@ -18,7 +18,7 @@ readonly OUTPUT="{{output}}"
 function add_to_tar() {
     content=$1
     tar_path=$2
-    echo >>"${OUTPUT}" "${tar_path} uid=0 gid=0 mode=0755 time=1672560000 type=file content=${content}"
+    echo >>"${OUTPUT}" "${tar_path} uid=0 gid=0 mode=0755 time=1672560000 type=file nlink=1 content=${content}"
 }
 
 MANIFEST_DIGEST=$(${JQ} -r '.manifests[0].digest | sub(":"; "/")' "${INDEX_FILE}" | "${COREUTILS}" tr  -d '"')


### PR DESCRIPTION
Mitigates https://github.com/buildbarn/bb-remote-execution/issues/162 while https://github.com/libarchive/libarchive/pull/2587 isn't released yet.

OCI layout should be deduplicated already as blobs are stored content-addressable, so setting nlink=1 to disallow detection and creation of hardlinks within tarball should be safe