### PR TITLE
Add missing dependency to //cosign:defs

### DIFF
--- a/cosign/BUILD.bazel
+++ b/cosign/BUILD.bazel
@@ -9,7 +9,10 @@ bzl_library(
     name = "defs",
     srcs = ["defs.bzl"],
     visibility = ["//visibility:public"],
-    deps = ["//cosign/private:sign"],
+    deps = [
+        "//cosign/private:attest",
+        "//cosign/private:sign",
+    ],
 )
 
 bzl_library(


### PR DESCRIPTION
The cosign/defs.bzl also [depends on attest.bzl](https://github.com/bazel-contrib/rules_oci/blob/main/cosign/defs.bzl#L3). I suppose this dependency should be declared in bzl library.