### PR TITLE
Fix static content example

### DIFF
--- a/docs/static_content.md
+++ b/docs/static_content.md
@@ -57,7 +57,7 @@ filegroup(
 tar(
     name = "static_tar",
     srcs = [":static"],
-    mutate = mutate(package_dir = "/usr/share/nginx/html"),
+    mutate = mutate(package_dir = "usr/share/nginx/html"),
 )
 
 oci_image(


### PR DESCRIPTION
Removed the leading slash of the `package_dir` to avoid running into bazel-contrib/bazel-lib#1031.