### PR TITLE
feat(oci): make repository attribute optional in oci_push (#822)

### DIFF
--- a/docs/push.md
+++ b/docs/push.md
@@ -158,8 +158,8 @@ multirun(
 | <a id="oci_push_rule-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="oci_push_rule-image"></a>image |  Label to an oci_image or oci_image_index   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 | <a id="oci_push_rule-remote_tags"></a>remote_tags |  a text file containing tags, one per line. These are passed to [`crane tag`]( https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_tag.md)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
-| <a id="oci_push_rule-repository"></a>repository |  Repository URL where the image will be signed at, e.g.: `index.docker.io/<user>/image`. Digests and tags are not allowed.   | String | optional |  `""`  |
-| <a id="oci_push_rule-repository_file"></a>repository_file |  The same as 'repository' but in a file. This allows pushing to different repositories based on stamping.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="oci_push_rule-repository"></a>repository |  Repository URL where the image will be signed at, e.g.: `index.docker.io/<user>/image`. Digests and tags are not allowed. If this attribute is not set, the repository must be passed at runtime via the `--repository` flag.   | String | optional |  `""`  |
+| <a id="oci_push_rule-repository_file"></a>repository_file |  The same as 'repository' but in a file. This allows pushing to different repositories based on stamping. If this attribute is not set, the repository must be passed at runtime via the `--repository` flag.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 
 
 <a id="oci_push"></a>

--- a/examples/push/BUILD.bazel
+++ b/examples/push/BUILD.bazel
@@ -29,6 +29,12 @@ oci_push(
     repository = "index.docker.io/<ORG>/image",
 )
 
+oci_push(
+    name = "push_image_wo_repository",
+    image = ":image",
+    remote_tags = ["latest"],
+)
+
 oci_image_index(
     name = "image_index",
     images = [
@@ -87,15 +93,26 @@ sh_test(
         "$(location :push_image_index)",
         "$(location :push_image_repository_file)",
         "$(location :push_image_wo_tags)",
+        "$(location :push_image_wo_repository)",
     ],
     data = [
         ":push_image",
         ":push_image_index",
         ":push_image_repository_file",
         ":push_image_wo_tags",
+        ":push_image_wo_repository",
         "@oci_crane_toolchains//:current_toolchain",
     ],
     toolchains = [
         "@oci_crane_toolchains//:current_toolchain",
+    ],
+)
+
+sh_test(
+    name = "test_push_image_wo_repository_fails",
+    srcs = ["test_push_image_wo_repository_fails.bash"],
+    args = ["$(location :push_image_wo_repository)"],
+    data = [
+        ":push_image_wo_repository",
     ],
 )

--- a/examples/push/test.bash
+++ b/examples/push/test.bash
@@ -6,6 +6,7 @@ readonly PUSH_IMAGE="$2"
 readonly PUSH_IMAGE_INDEX="$3"
 readonly PUSH_IMAGE_REPOSITORY_FILE="$4"
 readonly PUSH_IMAGE_WO_TAGS="$5"
+readonly PUSH_IMAGE_WO_REPOSITORY="$6"
 
 # start a registry
 output=$(mktemp)
@@ -55,3 +56,8 @@ if [ "${TAGS}" != "custom" ]; then
     echo "${TAGS}"
     exit 1
 fi
+
+# should push image without repository with default tags
+REPOSITORY="${REGISTRY}/local-wo-repository"
+"${PUSH_IMAGE_WO_REPOSITORY}" --repository "${REPOSITORY}"
+"${CRANE}" digest "$REPOSITORY:latest"

--- a/examples/push/test_push_image_wo_repository_fails.bash
+++ b/examples/push/test_push_image_wo_repository_fails.bash
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -o pipefail -o errexit -o nounset
+
+readonly PUSH_IMAGE_WO_REPOSITORY="$1"
+
+# Run the oci_push target and check that it fails with an error message.
+if ! "$PUSH_IMAGE_WO_REPOSITORY" &> output.txt; then
+  cat output.txt
+  grep "ERROR: repository not set. Please pass --repository flag." output.txt
+else
+  echo "Expected oci_push to fail, but it succeeded."
+  exit 1
+fi

--- a/oci/private/push.bzl
+++ b/oci/private/push.bzl
@@ -165,12 +165,13 @@ _attrs = {
     "repository": attr.string(
         doc = """\
         Repository URL where the image will be signed at, e.g.: `index.docker.io/<user>/image`.
-        Digests and tags are not allowed.
+        Digests and tags are not allowed. If this attribute is not set, the repository must be passed at runtime via the `--repository` flag.
         """,
     ),
     "repository_file": attr.label(
         doc = """\
         The same as 'repository' but in a file. This allows pushing to different repositories based on stamping.
+        If this attribute is not set, the repository must be passed at runtime via the `--repository` flag.
         """,
         allow_single_file = True,
     ),
@@ -231,8 +232,6 @@ def _impl(ctx):
     elif ctx.attr.repository_file:
         files.append(ctx.file.repository_file)
         substitutions["{{repository_file}}"] = ctx.file.repository_file.short_path
-    else:
-        fail("must specify exactly one of 'repository_file' or 'repository'")
 
     if ctx.attr.remote_tags:
         files.append(ctx.file.remote_tags)

--- a/oci/private/push.sh.tpl
+++ b/oci/private/push.sh.tpl
@@ -56,6 +56,11 @@ while (( $# > 0 )); do
   esac
 done
 
+if [[ -z "${REPOSITORY}" ]]; then
+  echo "ERROR: repository not set. Please pass --repository flag." >&2
+  exit 1
+fi
+
 DIGEST=$("${JQ}" -r '.manifests[0].digest' "${IMAGE_DIR}/index.json")
 
 REFS=$(mktemp)


### PR DESCRIPTION
This makes the `repository` and `repository_file` attributes of the `oci_push` rule optional. If neither is specified, the repository must be provided at runtime via the `--repository` flag.

This allows for more flexible usage of the `oci_push` rule, where the repository is not known at build time, for example in tutorials and examples.