### PR TITLE
feat(cosign): make repository attribute optional in cosign rules

### DIFF
--- a/cosign/private/attest.sh.tpl
+++ b/cosign/private/attest.sh.tpl
@@ -7,10 +7,11 @@ readonly IMAGE_DIR="{{image_dir}}"
 readonly DIGEST=$("${JQ}" -r '.manifests[].digest' "${IMAGE_DIR}/index.json")
 readonly FIXED_ARGS=({{fixed_args}})
 
-
 # set $@ to be FIXED_ARGS+$@
-ARGS=(${FIXED_ARGS[@]} $@)
-set -- ${ARGS[@]}
+ALL_ARGS=(${FIXED_ARGS[@]+"${FIXED_ARGS[@]}"} "$@")
+if [[ ${#ALL_ARGS[@]} -gt 0 ]]; then
+  set -- "${ALL_ARGS[@]}"
+fi
 
 REPOSITORY=""
 ARGS=()
@@ -22,6 +23,11 @@ while (( $# > 0 )); do
     *) ARGS+=( "$1" ); shift ;;
     esac
 done
+
+if [[ -z "${REPOSITORY}" ]]; then
+    echo "ERROR: repository not set. Please pass --repository flag or set the 'repository' attribute in the rule." >&2
+    exit 1
+fi
 
 exec "${COSIGN}" attest "${REPOSITORY}@${DIGEST}" ${ARGS[@]+"${ARGS[@]}"}
 

--- a/cosign/private/sign.sh.tpl
+++ b/cosign/private/sign.sh.tpl
@@ -8,8 +8,10 @@ readonly DIGEST=$("${JQ}" -r '.manifests[].digest' "${IMAGE_DIR}/index.json")
 readonly FIXED_ARGS=({{fixed_args}})
 
 # set $@ to be FIXED_ARGS+$@
-ARGS=(${FIXED_ARGS[@]} $@)
-set -- ${ARGS[@]}
+ALL_ARGS=(${FIXED_ARGS[@]+"${FIXED_ARGS[@]}"} "$@")
+if [[ ${#ALL_ARGS[@]} -gt 0 ]]; then
+  set -- "${ALL_ARGS[@]}"
+fi
 
 REPOSITORY=""
 ARGS=()
@@ -21,6 +23,11 @@ while (( $# > 0 )); do
     *) ARGS+=( "$1" ); shift ;;
     esac
 done
+
+if [[ -z "${REPOSITORY}" ]]; then
+    echo "ERROR: repository not set. Please pass --repository flag or set the 'repository' attribute in the rule." >&2
+    exit 1
+fi
 
 exec "${COSIGN}" sign "${REPOSITORY}@${DIGEST}" ${ARGS[@]+"${ARGS[@]}"}
 

--- a/examples/attest/BUILD.bazel
+++ b/examples/attest/BUILD.bazel
@@ -48,3 +48,43 @@ sh_test(
         "@jq_toolchains//:resolved_toolchain",
     ],
 )
+
+cosign_attest(
+    name = "attest_no_repo",
+    image = ":image",
+    predicate = ":sbom_generated.spdx",
+    type = "spdx",
+)
+
+sh_test(
+    name = "test_attest_no_repo_fails",
+    srcs = ["test_attest_no_repo_fails.bash"],
+    args = ["$(location :attest_no_repo)"],
+    data = [":attest_no_repo"],
+)
+
+sh_test(
+    name = "test_attest_no_repo_passes",
+    srcs = ["test_attest_no_repo_passes.bash"],
+    args = [
+        "$(JQ_BIN)",
+        "$(COSIGN_BIN)",
+        "$(CRANE_BIN)",
+        "$(location :attest_no_repo)",
+        "$(location :image)",
+        "$(location sbom.spdx)",
+    ],
+    data = [
+        "sbom.spdx",
+        ":attest_no_repo",
+        ":image",
+        "@jq_toolchains//:resolved_toolchain",
+        "@oci_cosign_toolchains//:current_toolchain",
+        "@oci_crane_toolchains//:current_toolchain",
+    ],
+    toolchains = [
+        "@oci_cosign_toolchains//:current_toolchain",
+        "@oci_crane_toolchains//:current_toolchain",
+        "@jq_toolchains//:resolved_toolchain",
+    ],
+)

--- a/examples/attest/test_attest_no_repo_fails.bash
+++ b/examples/attest/test_attest_no_repo_fails.bash
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -o pipefail -o errexit -o nounset
+
+readonly IMAGE_ATTESTER="$1"
+
+# Run the cosign_attest target and check that it fails with the expected error message.
+if ! "$IMAGE_ATTESTER" &> output.txt; then
+  cat output.txt
+  grep "ERROR: repository not set. Please pass --repository flag or set the 'repository' attribute in the rule." output.txt
+else
+  echo "Expected cosign_attest to fail, but it succeeded."
+  exit 1
+fi

--- a/examples/attest/test_attest_no_repo_passes.bash
+++ b/examples/attest/test_attest_no_repo_passes.bash
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -o pipefail -o errexit -o nounset
+
+readonly JQ="${1/external\//../}"
+readonly COSIGN="${2/external\//../}"
+readonly CRANE="${3/external\//../}"
+readonly ATTACHER_NO_REPO="$4"
+readonly IMAGE_PATH="$5"
+readonly SBOM_PATH="$6"
+
+# start a registry
+output=$(mktemp)
+$CRANE registry serve --address=localhost:0 >> "$output" 2>&1 &
+timeout=$((SECONDS+10))
+while [ "${SECONDS}" -lt "${timeout}" ]; do
+    port="$(sed -nr 's/.+serving on port ([0-9]+)/\1/p' < "$output")"
+    [ -n "${port}" ] && break
+done
+
+readonly REPOSITORY="localhost:$port/local" 
+
+# generate key
+COSIGN_PASSWORD=123 "${COSIGN}" generate-key-pair 
+
+REF=$("${CRANE}" push "${IMAGE_PATH}" "${REPOSITORY}")
+
+# attach the sbom
+COSIGN_PASSWORD=123 "${ATTACHER_NO_REPO}" --repository "${REPOSITORY}" --key=cosign.key -y
+
+# download the sbom
+"${COSIGN}" verify-attestation "$REF" --key=cosign.pub --type spdx | "${JQ}" -r '.payload' | base64 --decode | "${JQ}" -r '.predicate' > "$TEST_TMPDIR/download.sbom" 
+
+diff -u --ignore-space-change --strip-trailing-cr "$SBOM_PATH"  "$TEST_TMPDIR/download.sbom" || (echo "FAIL: downloaded SBOM does not match the original" && exit 1)

--- a/examples/sign/BUILD.bazel
+++ b/examples/sign/BUILD.bazel
@@ -43,3 +43,39 @@ sh_test(
         "@jq_toolchains//:resolved_toolchain",
     ],
 )
+
+cosign_sign(
+    name = "sign_no_repo",
+    image = ":image",
+)
+
+sh_test(
+    name = "test_sign_no_repo_fails",
+    srcs = ["test_sign_no_repo_fails.bash"],
+    args = ["$(location :sign_no_repo)"],
+    data = [":sign_no_repo"],
+)
+
+sh_test(
+    name = "test_sign_no_repo_passes",
+    srcs = ["test_sign_no_repo_passes.bash"],
+    args = [
+        "$(JQ_BIN)",
+        "$(CRANE_BIN)",
+        "$(COSIGN_BIN)",
+        "$(location :sign_no_repo)",
+        "$(location :image)",
+    ],
+    data = [
+        ":image",
+        ":sign_no_repo",
+        "@jq_toolchains//:resolved_toolchain",
+        "@oci_cosign_toolchains//:current_toolchain",
+        "@oci_crane_toolchains//:current_toolchain",
+    ],
+    toolchains = [
+        "@jq_toolchains//:resolved_toolchain",
+        "@oci_crane_toolchains//:current_toolchain",
+        "@oci_cosign_toolchains//:current_toolchain",
+    ],
+)

--- a/examples/sign/test_sign_no_repo_fails.bash
+++ b/examples/sign/test_sign_no_repo_fails.bash
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -o pipefail -o errexit -o nounset
+
+readonly IMAGE_SIGNER="$1"
+
+# Run the cosign_sign target and check that it fails with the expected error message.
+if ! "$IMAGE_SIGNER" &> output.txt; then
+  cat output.txt
+  grep "ERROR: repository not set. Please pass --repository flag or set the 'repository' attribute in the rule." output.txt
+else
+  echo "Expected cosign_sign to fail, but it succeeded."
+  exit 1
+fi

--- a/examples/sign/test_sign_no_repo_passes.bash
+++ b/examples/sign/test_sign_no_repo_passes.bash
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -o pipefail -o errexit -o nounset
+
+readonly JQ="${1/external\//../}"
+readonly CRANE="${2/external\//../}"
+readonly COSIGN="${3/external\//../}"
+readonly IMAGE_SIGNER_NO_REPO="$4"
+readonly IMAGE="$5"
+
+# start a registry
+output=$(mktemp)
+$CRANE registry serve --address=localhost:0 >> "$output" 2>&1 &
+timeout=$((SECONDS+10))
+while [ "${SECONDS}" -lt "${timeout}" ]; do
+    port="$(sed -nr 's/.+serving on port ([0-9]+)/\1/p' < "$output")"
+    [ -n "${port}" ] && break
+done
+
+readonly REPOSITORY="localhost:$port/local" 
+DIGEST=""
+DIGEST=$("$JQ" -r '.manifests[0].digest' "$IMAGE/index.json")
+readonly DIGEST
+
+# TODO: make this test sign by digest once https://github.com/sigstore/cosign/issues/1905 is fixed.
+"${CRANE}" push "${IMAGE}" "${REPOSITORY}@${DIGEST}"
+
+# Create key-pair
+COSIGN_PASSWORD=123 "${COSIGN}" generate-key-pair 
+
+# Sign the image at remote registry
+echo "y" | COSIGN_PASSWORD=123 "${IMAGE_SIGNER_NO_REPO}" --repository="${REPOSITORY}" --key=cosign.key
+
+# Now push the image
+REF=$("${CRANE}" push "${IMAGE}" "${REPOSITORY}")
+
+# Verify using the Tag
+"${COSIGN}" verify "${REPOSITORY}:latest" --key=cosign.pub
+
+# Verify using the Digest
+"${COSIGN}" verify "${REF}" --key=cosign.pub


### PR DESCRIPTION
This makes the `repository` attribute of the `cosign_sign` and `cosign_attest` rules optional. If not specified, the repository must be provided at runtime via the `--repository` flag.

This allows for more flexible usage of the cosign rules, where the repository is not known at build time. This is useful for example in cases where the code is being provided as an example or a codelab.