### PR TITLE
build: Update bazel_skylib dependency

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,7 +8,7 @@ module(
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.7.2")
 bazel_dep(name = "bazel_features", version = "1.10.0")
-bazel_dep(name = "bazel_skylib", version = "1.5.0")
+bazel_dep(name = "bazel_skylib", version = "1.8.1")
 bazel_dep(name = "platforms", version = "0.0.8")
 
 oci = use_extension("//oci:extensions.bzl", "oci")


### PR DESCRIPTION
Newer versions address a warning about a deprecated target:

https://github.com/bazelbuild/bazel-skylib/pull/574