### PR TITLE
fix: Add arch_dependent and os_dependent flags to buildx module exte…

### DIFF
--- a/examples/dockerfile/buildx.bzl
+++ b/examples/dockerfile/buildx.bzl
@@ -246,4 +246,6 @@ buildx = module_extension(
     tag_classes = {
         "toolchains": toolchains,
     },
+    arch_dependent = True,
+    os_dependent = True,
 )


### PR DESCRIPTION
The buildx repository rule generate a lockfile that has a platform specific `configure_buildx` block that breaks when used across platforms (ie: a MODULE.bazel.lock generated on OSX breaks on Linux_amd64).

ex: Module.bazel.lock
```diff
"buildx": {
    "repoRuleId": "@@//build_utils/docker:buildx.bzl%configure_buildx",
    "attributes": {
+     "buildx": "@@+buildx+buildx_darwin-arm64//file:downloaded",
      "buildx_platforms": {
        "@@+buildx+buildx_linux-amd64//file:file": "@bazel_tools//src/conditions:linux_x86_64",
        "@@+buildx+buildx_linux-arm64//file:file": "@bazel_tools//src/conditions:linux_aarch64",
        "@@+buildx+buildx_darwin-amd64//file:file": "@bazel_tools//src/conditions:darwin_x86_64",
        "@@+buildx+buildx_darwin-arm64//file:file": "@bazel_tools//src/conditions:darwin_arm64"
      }
    }
  }
```

This specifies `arch_dependent` and  `os_dependent` on `module_extension` to workaround this issue.