### PR TITLE
Upgrade aspect_bazel_lib 2.7.2 -> 2.21.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,7 +5,7 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "aspect_bazel_lib", version = "2.7.2")
+bazel_dep(name = "aspect_bazel_lib", version = "2.21.1")
 bazel_dep(name = "bazel_features", version = "1.10.0")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "platforms", version = "0.0.8")

--- a/docs/image.md
+++ b/docs/image.md
@@ -11,6 +11,8 @@ load("@rules_oci//oci:defs.bzl", ...)
 ## oci_image_rule
 
 <pre>
+load("@rules_oci//oci:defs.bzl", "oci_image_rule")
+
 oci_image_rule(<a href="#oci_image_rule-name">name</a>, <a href="#oci_image_rule-annotations">annotations</a>, <a href="#oci_image_rule-architecture">architecture</a>, <a href="#oci_image_rule-base">base</a>, <a href="#oci_image_rule-cmd">cmd</a>, <a href="#oci_image_rule-created">created</a>, <a href="#oci_image_rule-entrypoint">entrypoint</a>, <a href="#oci_image_rule-env">env</a>, <a href="#oci_image_rule-exposed_ports">exposed_ports</a>,
                <a href="#oci_image_rule-labels">labels</a>, <a href="#oci_image_rule-os">os</a>, <a href="#oci_image_rule-resource_set">resource_set</a>, <a href="#oci_image_rule-tars">tars</a>, <a href="#oci_image_rule-user">user</a>, <a href="#oci_image_rule-variant">variant</a>, <a href="#oci_image_rule-volumes">volumes</a>, <a href="#oci_image_rule-workdir">workdir</a>)
 </pre>
@@ -91,6 +93,8 @@ oci_image(
 ## oci_image
 
 <pre>
+load("@rules_oci//oci:defs.bzl", "oci_image")
+
 oci_image(<a href="#oci_image-name">name</a>, <a href="#oci_image-created">created</a>, <a href="#oci_image-labels">labels</a>, <a href="#oci_image-annotations">annotations</a>, <a href="#oci_image-env">env</a>, <a href="#oci_image-cmd">cmd</a>, <a href="#oci_image-entrypoint">entrypoint</a>, <a href="#oci_image-exposed_ports">exposed_ports</a>, <a href="#oci_image-volumes">volumes</a>, <a href="#oci_image-kwargs">kwargs</a>)
 </pre>
 

--- a/docs/image_index.md
+++ b/docs/image_index.md
@@ -11,6 +11,8 @@ load("@rules_oci//oci:defs.bzl", ...)
 ## oci_image_index_rule
 
 <pre>
+load("@rules_oci//oci:defs.bzl", "oci_image_index_rule")
+
 oci_image_index_rule(<a href="#oci_image_index_rule-name">name</a>, <a href="#oci_image_index_rule-images">images</a>, <a href="#oci_image_index_rule-platforms">platforms</a>)
 </pre>
 
@@ -86,6 +88,8 @@ oci_image_index(
 ## oci_image_index
 
 <pre>
+load("@rules_oci//oci:defs.bzl", "oci_image_index")
+
 oci_image_index(<a href="#oci_image_index-name">name</a>, <a href="#oci_image_index-kwargs">kwargs</a>)
 </pre>
 

--- a/docs/load.md
+++ b/docs/load.md
@@ -25,6 +25,8 @@ docker run --rm my-repository:latest
 ## oci_load
 
 <pre>
+load("@rules_oci//oci/private:load.bzl", "oci_load")
+
 oci_load(<a href="#oci_load-name">name</a>, <a href="#oci_load-format">format</a>, <a href="#oci_load-image">image</a>, <a href="#oci_load-loader">loader</a>, <a href="#oci_load-repo_tags">repo_tags</a>)
 </pre>
 

--- a/docs/pull.md
+++ b/docs/pull.md
@@ -161,6 +161,8 @@ In this example, we provide a `www_authenticate_challenges` attribute to the `oc
 ## oci_pull
 
 <pre>
+load("@rules_oci//oci:pull.bzl", "oci_pull")
+
 oci_pull(<a href="#oci_pull-name">name</a>, <a href="#oci_pull-www_authenticate_challenges">www_authenticate_challenges</a>, <a href="#oci_pull-image">image</a>, <a href="#oci_pull-repository">repository</a>, <a href="#oci_pull-registry">registry</a>, <a href="#oci_pull-platforms">platforms</a>, <a href="#oci_pull-digest">digest</a>, <a href="#oci_pull-tag">tag</a>,
          <a href="#oci_pull-reproducible">reproducible</a>, <a href="#oci_pull-is_bzlmod">is_bzlmod</a>, <a href="#oci_pull-config">config</a>, <a href="#oci_pull-bazel_tags">bazel_tags</a>)
 </pre>

--- a/docs/push.md
+++ b/docs/push.md
@@ -11,6 +11,8 @@ load("@rules_oci//oci:defs.bzl", ...)
 ## oci_push_rule
 
 <pre>
+load("@rules_oci//oci:defs.bzl", "oci_push_rule")
+
 oci_push_rule(<a href="#oci_push_rule-name">name</a>, <a href="#oci_push_rule-image">image</a>, <a href="#oci_push_rule-remote_tags">remote_tags</a>, <a href="#oci_push_rule-repository">repository</a>, <a href="#oci_push_rule-repository_file">repository_file</a>)
 </pre>
 
@@ -167,6 +169,8 @@ multirun(
 ## oci_push
 
 <pre>
+load("@rules_oci//oci:defs.bzl", "oci_push")
+
 oci_push(<a href="#oci_push-name">name</a>, <a href="#oci_push-remote_tags">remote_tags</a>, <a href="#oci_push-kwargs">kwargs</a>)
 </pre>
 

--- a/e2e/assertion/MODULE.bazel
+++ b/e2e/assertion/MODULE.bazel
@@ -2,7 +2,7 @@
 
 bazel_dep(name = "rules_go", version = "0.53.0")
 bazel_dep(name = "gazelle", version = "0.42.0")
-bazel_dep(name = "aspect_bazel_lib", version = "2.7.2")
+bazel_dep(name = "aspect_bazel_lib", version = "2.21.1")
 bazel_dep(name = "rules_oci", version = "0.0.0")
 bazel_dep(name = "external_wksp", version = "1.0")
 

--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -1,10 +1,10 @@
 "Bazel dependencies"
 
-bazel_dep(name = "aspect_bazel_lib", version = "2.7.2")
+bazel_dep(name = "aspect_bazel_lib", version = "2.21.1")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "platforms", version = "0.0.8")
 bazel_dep(name = "rules_oci", version = "0.0.0")
-bazel_dep(name = "container_structure_test", version = "1.15.0")
+bazel_dep(name = "container_structure_test", version = "1.19.1")
 
 local_path_override(
     module_name = "rules_oci",

--- a/e2e/wasm/MODULE.bazel
+++ b/e2e/wasm/MODULE.bazel
@@ -1,5 +1,5 @@
 bazel_dep(name = "rules_oci", version = "0.0.0")
-bazel_dep(name = "aspect_bazel_lib", version = "2.7.2")
+bazel_dep(name = "aspect_bazel_lib", version = "2.21.1")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "platforms", version = "0.0.8")
 bazel_dep(name = "rules_rust", version = "0.45.1")

--- a/examples/dockerfile/MODULE.bazel
+++ b/examples/dockerfile/MODULE.bazel
@@ -3,7 +3,7 @@
 module(name = "dockerfile")
 
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
-bazel_dep(name = "aspect_bazel_lib", version = "2.7.2")
+bazel_dep(name = "aspect_bazel_lib", version = "2.21.1")
 bazel_dep(name = "rules_oci", version = "2.2.5")
 bazel_dep(name = "rules_go", version = "0.53.0")
 


### PR DESCRIPTION
This newer version of aspect_bazel_lib no longer uses local_config_platform, which will not be available in bazel 9.x.