### PR TITLE
support nerdctl (containerd)

### DIFF
--- a/docs/load.md
+++ b/docs/load.md
@@ -103,7 +103,7 @@ multirun(
 | <a id="oci_load-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="oci_load-format"></a>format |  Format of image to generate. Options are: docker, oci. Currently, when the input image is an image_index, only oci is supported, and when the input image is an image, only docker is supported. Conversions between formats may be supported in the future.   | String | optional |  `"docker"`  |
 | <a id="oci_load-image"></a>image |  Label of a directory containing an OCI layout, typically `oci_image`   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
-| <a id="oci_load-loader"></a>loader |  Alternative target for a container cli tool that will be used to load the image into the local engine when using `bazel run` on this target.<br><br>By default, we look for `docker` or `podman` on the PATH, and run the `load` command.<br><br>See the _run_template attribute for the script that calls this loader tool.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="oci_load-loader"></a>loader |  Alternative target for a container cli tool that will be used to load the image into the local engine when using `bazel run` on this target.<br><br>By default, we look for `docker` or `podman` or `nerdctl` on the PATH, and run the `load` command.<br><br>See the _run_template attribute for the script that calls this loader tool.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="oci_load-repo_tags"></a>repo_tags |  a file containing repo_tags, one per line.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 
 

--- a/oci/private/load.bzl
+++ b/oci/private/load.bzl
@@ -109,7 +109,7 @@ attrs = {
             Alternative target for a container cli tool that will be
             used to load the image into the local engine when using `bazel run` on this target.
 
-            By default, we look for `docker` or `podman` on the PATH, and run the `load` command.
+            By default, we look for `docker` or `podman` or `nerdctl` on the PATH, and run the `load` command.
 
             See the _run_template attribute for the script that calls this loader tool.
             """,

--- a/oci/private/load.sh.tpl
+++ b/oci/private/load.sh.tpl
@@ -18,7 +18,7 @@ elif command -v podman &> /dev/null; then
 elif command -v nerdctl &> /dev/null; then
     CONTAINER_CLI="nerdctl"
 else
-    echo >&2 "Neither docker or podman or nerdctl could be found."
+    echo >&2 "Neither docker, podman nor nerdctl could be found."
     echo >&2 "To use a different container runtime, pass an executable to the 'loader' attribute of oci_tarball."
     exit 1
 fi


### PR DESCRIPTION
Allow use of nerdctl for image loading

When this is used nerdctl must be preinstalled and on the path
