### PR TITLE
Fix token overwritten by empty access_token field (fixes #801)

### DIFF
--- a/oci/private/authn.bzl
+++ b/oci/private/authn.bzl
@@ -372,7 +372,7 @@ def _get_token(rctx, state, registry, repository):
             token = ""
             if "token" in auth:
                 token = auth["token"]
-            if "access_token" in auth:
+            if "access_token" in auth and auth["access_token"]:
                 token = auth["access_token"]
             if token == "":
                 if allow_fail:


### PR DESCRIPTION
Fixes #801

## Problem

When a registry returns both `"token"` and `"access_token"` fields in the authentication response, the current logic unconditionally overwrites the
token value with access_token, even when access_token is empty.

This causes authentication failures with registries like Harbor that return:

```json
{"token": "eyJ...", "access_token": "", "expires_in": 1800, "issued_at": "..."}
```

The second `if` statement overwrites the valid JWT token with an empty string, leading to "could not find token" errors.

### Solution

Changed the condition from:

```starlark
if "access_token" in auth:
    token = auth["access_token"]
```

To:

```starlark
if "access_token" in auth and auth["access_token"]:
    token = auth["access_token"]
```

This only uses `access_token` when it's non-empty, fixing authentication for registries that return both fields with an empty `access_token`.

### Tested

- ✅ Harbor registry (public repos without Docker credentials)
- ✅ Docker Hub (existing functionality unchanged)
