### PR TITLE
Fix muitlarch image builds by using host architecture for jq and crane 

### DIFF
--- a/oci/private/push.bzl
+++ b/oci/private/push.bzl
@@ -167,9 +167,6 @@ _attrs = {
         """,
         allow_single_file = True,
     ),
-    "_allowlist_function_transition": attr.label(
-        default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
-    ),
     "_crane": attr.label(
         default = "@oci_crane_toolchains//:current_toolchain",
         cfg = "exec",
@@ -190,8 +187,8 @@ def _quote_args(args):
     return ["\"{}\"".format(arg) for arg in args]
 
 def _impl(ctx):
-    crane = ctx.attr._crane[0][platform_common.ToolchainInfo]
-    jq = ctx.attr._jq[0][platform_common.ToolchainInfo]
+    crane = ctx.attr._crane[platform_common.ToolchainInfo]
+    jq = ctx.attr._jq[platform_common.ToolchainInfo]
 
     if ctx.attr.repository and ctx.attr.repository_file:
         fail("must specify exactly one of 'repository_file' or 'repository'")


### PR DESCRIPTION
This PR builds on #794 to fix the failing CI jobs. 

Multiarch image builds can fail due to the target architecture for jq and crane. For example if you are building an arm64 image on a x86 machine a failure similar to this will occur:

```
line 52: ../jq_linux_arm64/jq: cannot execute binary file: Exec format error
```
As jq and crane run on the host building the images the host architecture should be used rather than the target arch. 
