### PR TITLE
Update platform versions in presubmit.yml

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -3,7 +3,7 @@ bcr_test_module:
   matrix:
     bazel: ["6.x", "7.x"]
     # TODO(#97): add windows
-    platform: ["debian10", "ubuntu2004"]
+    platform: ["debian11", "ubuntu2204"]
   tasks:
     test_linux:
       name: "Run test module"


### PR DESCRIPTION
Ubuntu 20.04 and Debian 10 are end of life. Bumping them to 22.04 and 11.