### PR TITLE
Add Bazel version '8.x' to BCR matrix

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,7 +1,7 @@
 bcr_test_module:
   module_path: "e2e/smoke"
   matrix:
-    bazel: ["6.x", "7.x"]
+    bazel: ["6.x", "7.x", "8.x"]
     # TODO(#97): add windows
     platform: ["debian10", "ubuntu2004"]
   tasks:


### PR DESCRIPTION
This project already uses bazel 8 so we should also test against in on the BCR presubmit