### PR TITLE
ci: Add conventional commits check

### DIFF
--- a/.github/workflows/conventional-commits.yaml
+++ b/.github/workflows/conventional-commits.yaml
@@ -1,0 +1,16 @@
+name: Verify PR title/description
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+permissions:
+  pull-requests: read
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Conventional commits are required for https://github.com/bazel-contrib/rules_oci/blob/main/.github/workflows/tag.yaml to work correctly so having this enforced is super helpful.

We use this workflow in many places such as https://github.com/bazel-contrib/bazelrc-preset.bzl/blob/main/.github/workflows/conventional-commits.yaml or https://github.com/bazel-contrib/bazel-lib/blob/main/.github/workflows/conventional-commits.yaml