### PR TITLE
Add conventional commits check

### DIFF
--- a/.github/workflows/conventional-commits.yaml
+++ b/.github/workflows/conventional-commits.yaml
@@ -1,0 +1,16 @@
+name: Verify PR title/description
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+permissions:
+  pull-requests: read
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixing part of https://github.com/alexeagle/rules-doctor/actions/runs/20131461621/attempts/1#summary-57773718955. Why is this useful? See https://github.com/bazel-contrib/rules_nodejs/pull/3884#pullrequestreview-3564011248