### PR TITLE
feat: add support for tagging architecture specific images

### DIFF
--- a/docs/push.md
+++ b/docs/push.md
@@ -13,7 +13,7 @@ load("@rules_oci//oci:defs.bzl", ...)
 <pre>
 load("@rules_oci//oci:defs.bzl", "oci_push_rule")
 
-oci_push_rule(<a href="#oci_push_rule-name">name</a>, <a href="#oci_push_rule-image">image</a>, <a href="#oci_push_rule-remote_tags">remote_tags</a>, <a href="#oci_push_rule-repository">repository</a>, <a href="#oci_push_rule-repository_file">repository_file</a>)
+oci_push_rule(<a href="#oci_push_rule-name">name</a>, <a href="#oci_push_rule-image">image</a>, <a href="#oci_push_rule-remote_tags">remote_tags</a>, <a href="#oci_push_rule-repository">repository</a>, <a href="#oci_push_rule-repository_file">repository_file</a>, <a href="#oci_push_rule-tag_platform_images">tag_platform_images</a>)
 </pre>
 
 Push an oci_image or oci_image_index to a remote registry.
@@ -162,6 +162,7 @@ multirun(
 | <a id="oci_push_rule-remote_tags"></a>remote_tags |  a text file containing tags, one per line. These are passed to [`crane tag`]( https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_tag.md)   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="oci_push_rule-repository"></a>repository |  Repository URL where the image will be signed at, e.g.: `index.docker.io/<user>/image`. Digests and tags are not allowed. If this attribute is not set, the repository must be passed at runtime via the `--repository` flag.   | String | optional |  `""`  |
 | <a id="oci_push_rule-repository_file"></a>repository_file |  The same as 'repository' but in a file. This allows pushing to different repositories based on stamping. If this attribute is not set, the repository must be passed at runtime via the `--repository` flag.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="oci_push_rule-tag_platform_images"></a>tag_platform_images |  If true, tag platform specific images with each remote tag and an additional '-${os}-${arch}' suffix. This is useful for platforms that cannot handle OCI image indexes and instead require a reference to a platform specific image.   | Boolean | optional |  `False`  |
 
 
 <a id="oci_push"></a>

--- a/oci/private/push.bzl
+++ b/oci/private/push.bzl
@@ -167,6 +167,13 @@ _attrs = {
         """,
         allow_single_file = True,
     ),
+    "tag_platform_images": attr.bool(
+        doc = """\
+        If true, tag platform specific images with each remote tag and an additional
+        '-${os}-${arch}' suffix. This is useful for platforms that cannot handle OCI
+        image indexes and instead require a reference to a platform specific image.
+        """,
+    ),
     "_crane": attr.label(
         default = "@oci_crane_toolchains//:current_toolchain",
         cfg = "exec",
@@ -205,6 +212,7 @@ def _impl(ctx):
         "{{crane_path}}": to_rlocation_path(ctx, crane.crane_info.binary),
         "{{jq_path}}": to_rlocation_path(ctx, jq.jqinfo.bin),
         "{{image_dir}}": to_rlocation_path(ctx, ctx.file.image),
+        "{{tag_platform_images}}": "0",
         "{{fixed_args}}": "",
     }
 
@@ -217,6 +225,9 @@ def _impl(ctx):
     if ctx.attr.remote_tags:
         files.append(ctx.file.remote_tags)
         substitutions["{{tags}}"] = to_rlocation_path(ctx, ctx.file.remote_tags)
+
+    if ctx.attr.tag_platform_images:
+        substitutions["{{tag_platform_images}}"] = "1"
 
     ctx.actions.expand_template(
         template = ctx.file._push_sh_tpl,

--- a/oci/private/push.sh.tpl
+++ b/oci/private/push.sh.tpl
@@ -28,6 +28,10 @@ TAGS=()
 # global crane flags to be passed with every crane invocation
 GLOBAL_FLAGS=()
 
+# tag platform specific images as ${tag}-${os}-${arch} (for use with
+# AWS Lambda and other platforms that cannot handle multiarch OCI images).
+TAG_PLATFORM_IMAGES="{{tag_platform_images}}"
+
 # this will hold args specific to `crane push``
 ARGS=()
 
@@ -35,6 +39,9 @@ while (( $# > 0 )); do
   case $1 in
     (--allow-nondistributable-artifacts|--insecure|-v|--verbose)
       GLOBAL_FLAGS+=( "$1" )
+      shift;;
+    (-i|--tag-platform-images)
+      TAG_PLATFORM_IMAGES=1
       shift;;
     (--platform)
       GLOBAL_FLAGS+=( "--platform" "$2" )
@@ -65,16 +72,38 @@ if [[ -z "${REPOSITORY}" ]]; then
   exit 1
 fi
 
-DIGEST=$("${JQ}" -r '.manifests[0].digest' "${IMAGE_DIR}/index.json")
+MANIFEST_DIGEST=$("${JQ}" -r '.manifests[0].digest' "${IMAGE_DIR}/index.json")
+MANIFEST_FILE="${IMAGE_DIR}/blobs/${MANIFEST_DIGEST%%:*}/${MANIFEST_DIGEST##*:}"
+IMAGE_DIGESTS=$(${JQ} -r '.manifests[]? | [ .digest, .platform.os, .platform.architecture ] | @tsv ' "${MANIFEST_FILE}")
 
 REFS=$(mktemp)
-"${CRANE}" push "${GLOBAL_FLAGS[@]+"${GLOBAL_FLAGS[@]}"}" "${IMAGE_DIR}" "${REPOSITORY}@${DIGEST}" "${ARGS[@]+"${ARGS[@]}"}" --image-refs "${REFS}"
+"${CRANE}" push "${GLOBAL_FLAGS[@]+"${GLOBAL_FLAGS[@]}"}" "${IMAGE_DIR}" "${REPOSITORY}@${MANIFEST_DIGEST}" "${ARGS[@]+"${ARGS[@]}"}" --image-refs "${REFS}"
 
 for tag in "${TAGS[@]+"${TAGS[@]}"}"
 do
   "${CRANE}" tag "${GLOBAL_FLAGS[@]+"${GLOBAL_FLAGS[@]}"}" $(cat "${REFS}") "${tag}"
+  if [[ ${TAG_PLATFORM_IMAGES} -eq 1 ]]; then
+    echo "${IMAGE_DIGESTS}" | while read digest os arch ; do
+      if [[ -n "${os}" && -n "${arch}" ]]; then
+        "${CRANE}" tag "${REPOSITORY}@${digest}" "${tag}-${os}-${arch}"
+      fi
+    done
+  fi
 done
 
 if [[ -e "${TAGS_FILE:-}" ]]; then
-  cat "${TAGS_FILE}" | xargs -r -n1 "${CRANE}" tag "${GLOBAL_FLAGS[@]+"${GLOBAL_FLAGS[@]}"}" $(cat "${REFS}")
+  readarray -t tags < "${TAGS_FILE}"
+  for tag in "${tags[@]}"; do
+    if [[ -z "${tag}" ]]; then
+        continue
+    fi
+    "${CRANE}" tag "${GLOBAL_FLAGS[@]+"${GLOBAL_FLAGS[@]}"}" $(cat "${REFS}") "${tag}"
+    if [[ ${TAG_PLATFORM_IMAGES} -eq 1 ]]; then
+      echo "${IMAGE_DIGESTS}" | while read digest os arch ; do
+        if [[ -n "${os}" && -n "${arch}" ]]; then
+          "${CRANE}" tag "${REPOSITORY}@${digest}" "${tag}-${os}-${arch}"
+        fi
+      done
+    fi
+  done
 fi


### PR DESCRIPTION
Add a `tag_platform_images` attribute to `oci_push`, which if enabled, results in each platform specific image being tagged with each remote tag and an additional '-${os}-${arch}' suffix. This makes it possible to reference platform specific images as `${tag}-${os}-${arch}` (e.g. "v1.2.3-linux-arm64").

This makes it easier to use rules_oci and multi-image indexes, with systems that do not handle OCI image indexes (such as AWS Lambda) and instead require a reference to a platform specific image.