### PR TITLE
fix: Propagate non-zero `tar` exit in `load.sh`

### DIFF
--- a/oci/private/load.sh.tpl
+++ b/oci/private/load.sh.tpl
@@ -36,3 +36,4 @@ mtree_contents="${mtree_contents//"$manifest_root"/$manifest_runfiles_prefix}"
 "$CONTAINER_CLI" load --input <(
     "$TAR" --cd "$RUNFILES_DIR" --create --no-xattr --no-mac-metadata @- <<< "$mtree_contents"
 )
+wait $!


### PR DESCRIPTION
In `oci/private/load.sh.tpl` `tar` is invoked with [process substitution](https://www.gnu.org/software/bash/manual/html_node/Process-Substitution.html), which is suppressing it's exit code.

For `tar` errors to be handled, `wait $!` is needed.

As an aside, this class of issues can be linted against with [`shellcheck` `SC2312`](https://www.shellcheck.net/wiki/SC2312).