### PR TITLE
chore: update Bazel version matrix in presubmit.yml

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,7 +1,7 @@
 bcr_test_module:
   module_path: "e2e/smoke"
   matrix:
-    bazel: ["6.x", "7.x", "8.x"]
+    bazel: ["7.x", "8.x"]
     # TODO(#97): add windows
     platform: ["debian11", "ubuntu2204"]
   tasks:


### PR DESCRIPTION
Removed '6.x' from the Bazel version matrix.