### PR TITLE
fix(authn): run credential helper from the workspace root

### DIFF
--- a/oci/private/authn.bzl
+++ b/oci/private/authn.bzl
@@ -127,7 +127,10 @@ echo %1 | docker-credential-{} get """.format(helper_name),
 #!/usr/bin/env bash
 exec "docker-credential-{}" get <<< "$1" """.format(helper_name),
         )
-    result = rctx.execute([rctx.path(executable), raw_host])
+    result = rctx.execute(
+        [rctx.path(executable), raw_host],
+        working_directory = str(rctx.workspace_root),
+    )
     if result.return_code:
         if not allow_fail:
             fail("credential helper failed: \nSTDOUT:\n{}\nSTDERR:\n{}".format(result.stdout, result.stderr))


### PR DESCRIPTION
The credential helper subprocess invoked by `oci_pull` currently inherits whatever working directory Bazel picks (typically an internal output-base path), so helpers that read workspace-relative config (`.aws/config`, project-local credential files, custom helpers that resolve paths off the workspace root) fail to find them.

This passes `working_directory = str(rctx.workspace_root)` to `rctx.execute` so the helper runs from the workspace root.

Fixes #895.