### PR TITLE
feat(oci_image_index): support annotations attribute

### DIFF
--- a/examples/image_index/BUILD.bazel
+++ b/examples/image_index/BUILD.bazel
@@ -1,4 +1,6 @@
 load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
+load("@aspect_bazel_lib//lib:testing.bzl", "assert_contains")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index")
 load("@tar.bzl", "tar")
 
@@ -65,4 +67,90 @@ oci_image_index(
         ":linux_amd64",
         ":linux_arm64",
     ],
+)
+
+# Exercises the `annotations` attribute (inline-dict form, just like
+# oci_image accepts). The annotations end up on the image-index manifest
+# blob's top-level `.annotations`.
+oci_image_index(
+    name = "app_all_annotated",
+    annotations = {
+        "org.opencontainers.image.source": "https://github.com/bazel-contrib/rules_oci",
+        "org.opencontainers.image.revision": "deadbeef",
+    },
+    images = [":app"],
+    platforms = [
+        ":linux_amd64",
+        ":linux_arm64",
+    ],
+)
+
+# Extract the index manifest blob from the layout so we can grep it.
+genrule(
+    name = "app_all_annotated_manifest",
+    srcs = [":app_all_annotated"],
+    outs = ["app_all_annotated_manifest.json"],
+    cmd = """
+        set -euo pipefail
+        digest=$$($(JQ_BIN) -r '.manifests[0].digest | sub(":"; "/")' $(location :app_all_annotated)/index.json)
+        cp $(location :app_all_annotated)/blobs/$$digest $@
+    """,
+    toolchains = ["@jq_toolchains//:resolved_toolchain"],
+)
+
+assert_contains(
+    name = "check_index_source_annotation",
+    actual = ":app_all_annotated_manifest",
+    expected = "https://github.com/bazel-contrib/rules_oci",
+)
+
+assert_contains(
+    name = "check_index_revision_annotation",
+    actual = ":app_all_annotated_manifest",
+    expected = "deadbeef",
+)
+
+# Same test again, using the file-label form for `annotations` (a key=value
+# text file). Mirrors the pattern in examples/labels/BUILD.bazel.
+write_file(
+    name = "annotations_file",
+    out = "annotations.txt",
+    content = [
+        "org.opencontainers.image.source=https://github.com/bazel-contrib/rules_oci",
+        "org.opencontainers.image.revision=deadbeef",
+    ],
+)
+
+oci_image_index(
+    name = "app_all_annotated_from_file",
+    annotations = ":annotations_file",
+    images = [":app"],
+    platforms = [
+        ":linux_amd64",
+        ":linux_arm64",
+    ],
+)
+
+genrule(
+    name = "app_all_annotated_from_file_manifest",
+    srcs = [":app_all_annotated_from_file"],
+    outs = ["app_all_annotated_from_file_manifest.json"],
+    cmd = """
+        set -euo pipefail
+        digest=$$($(JQ_BIN) -r '.manifests[0].digest | sub(":"; "/")' $(location :app_all_annotated_from_file)/index.json)
+        cp $(location :app_all_annotated_from_file)/blobs/$$digest $@
+    """,
+    toolchains = ["@jq_toolchains//:resolved_toolchain"],
+)
+
+assert_contains(
+    name = "check_index_source_annotation_from_file",
+    actual = ":app_all_annotated_from_file_manifest",
+    expected = "https://github.com/bazel-contrib/rules_oci",
+)
+
+assert_contains(
+    name = "check_index_revision_annotation_from_file",
+    actual = ":app_all_annotated_from_file_manifest",
+    expected = "deadbeef",
 )

--- a/oci/defs.bzl
+++ b/oci/defs.bzl
@@ -60,7 +60,7 @@ def _digest(name, **kwargs):
         **kwargs
     )
 
-def oci_image_index(name, **kwargs):
+def oci_image_index(name, annotations = None, **kwargs):
     """Macro wrapper around [oci_image_index_rule](#oci_image_index_rule).
 
     Produces a target `[name].digest`, whose default output is a file containing the sha256 digest of the resulting image.
@@ -68,13 +68,26 @@ def oci_image_index(name, **kwargs):
 
     Args:
         name: name of resulting oci_image_index_rule
+        annotations: Annotations to apply to the index manifest.
+            May either be specified as a file (key=value pairs, one per line) or a dict of strings to specify values inline.
         **kwargs: other named arguments to [oci_image_index_rule](#oci_image_index_rule) and
             [common rule attributes](https://bazel.build/reference/be/common-definitions#common-attributes).
     """
     forwarded_kwargs = propagate_common_rule_attributes(kwargs)
 
+    if types.is_dict(annotations):
+        annotations_label = "{}_write_annotations".format(name)
+        write_file(
+            name = annotations_label,
+            out = "{}.annotations.txt".format(name),
+            content = ["{}={}".format(key, value) for (key, value) in annotations.items()],
+            **forwarded_kwargs
+        )
+        annotations = annotations_label
+
     oci_image_index_rule(
         name = name,
+        annotations = annotations,
         **kwargs
     )
 

--- a/oci/private/image_index.bzl
+++ b/oci/private/image_index.bzl
@@ -78,9 +78,13 @@ _attrs = {
     ),
     "platforms": attr.label_list(
         doc = """This feature is highly EXPERIMENTAL and not subject to our usual SemVer guarantees.
-A list of platform targets to build the image for. If specified, only one image can be specified in the images attribute.      
+A list of platform targets to build the image for. If specified, only one image can be specified in the images attribute.
 """,
         providers = [platform_common.PlatformInfo],
+    ),
+    "annotations": attr.label(
+        doc = "A file containing a dictionary of annotations to apply to the index manifest. Each line should be in the form `name=value`.",
+        allow_single_file = True,
     ),
     "_image_index_sh_tpl": attr.label(default = "image_index.sh.tpl", allow_single_file = True),
     "_allowlist_function_transition": attr.label(
@@ -121,8 +125,13 @@ def _oci_image_index_impl(ctx):
     args.add(output.path, format = "--output=%s")
     args.add_all(ctx.files.images, map_each = _expand_image_to_args, expand_directories = False)
 
+    inputs = list(ctx.files.images)
+    if ctx.attr.annotations:
+        args.add(ctx.file.annotations.path, format = "--annotations=%s")
+        inputs.append(ctx.file.annotations)
+
     ctx.actions.run(
-        inputs = ctx.files.images,
+        inputs = inputs,
         arguments = [args],
         outputs = [output],
         executable = launcher,

--- a/oci/private/image_index.sh.tpl
+++ b/oci/private/image_index.sh.tpl
@@ -50,16 +50,24 @@ function create_oci_layout() {
 
 CURRENT_IMAGE=""
 OUTPUT=""
+ANNOTATIONS=""
 
 for ARG in "$@"; do
     case "$ARG" in
         (--output=*) OUTPUT="${ARG#--output=}"; create_oci_layout "$OUTPUT" ;;
         (--image=*) CURRENT_IMAGE="${ARG#--image=}"; add_image "$CURRENT_IMAGE" "$OUTPUT" ;;
         (--blob=*) copy_blob "${CURRENT_IMAGE}" "$OUTPUT" "${ARG#--blob=}" ;;
+        (--annotations=*) ANNOTATIONS="${ARG#--annotations=}" ;;
         (*) echo "Unknown argument ${ARG}"; exit 1;;
     esac
 done
 
+if [[ -n "${ANNOTATIONS}" ]]; then
+    "${JQ}" --rawfile annotations "${ANNOTATIONS}" \
+            '.annotations += ([($annotations | split("\n") | .[] | select(. != ""))] | map(. | split("=")) | map({key: .[0], value: .[1:] | join("=")}) | from_entries)' \
+            "${OUTPUT}/manifest_list.json" > "${OUTPUT}/manifest_list.new.json"
+    "${COREUTILS}" cp --no-preserve=mode "${OUTPUT}/manifest_list.new.json" "${OUTPUT}/manifest_list.json"
+fi
 
 checksum=$("${COREUTILS}" sha256sum "${OUTPUT}/manifest_list.json" | "${COREUTILS}" cut -f 1 -d " ")
 size=$("${COREUTILS}" wc -c < "${OUTPUT}/manifest_list.json")


### PR DESCRIPTION
Adds an `annotations` attribute to `oci_image_index`, mirroring the existing one on `oci_image`. The macro accepts annotations as either an inline dict or a label to a key=value file; the underlying rule takes a file (the macro converts a dict via `write_file`, same as `oci_image`). Annotations are merged into the index manifest's top-level `.annotations` field before its digest is computed, so the wrapper's descriptor still matches the blob. The merge reuses the same jq filter `oci_image` uses, so behavior is consistent across the two rules.

Fixes #798.

Use case (from #798): GitHub Container Registry, Akuity Kargo, and other consumers look for `org.opencontainers.image.source` and `org.opencontainers.image.revision` on the index of multi-arch images to surface commit/repository links in their UIs. Without this attribute, users have to post-process the index outside Bazel.

Example:
```
  oci_image_index(
      name = "app",
      images = [":app_linux_amd64", ":app_linux_arm64"],
      annotations = {
          "org.opencontainers.image.source": "https://github.com/example/repo",
          "org.opencontainers.image.revision": "abc1234",
      },
  )
```