### PR TITLE
fix: make OCI helper actions explicit about toolchains

### DIFF
--- a/oci/private/image.bzl
+++ b/oci/private/image.bzl
@@ -131,6 +131,7 @@ def _calculate_descriptor(ctx, idx, layer, zstd, jq, coreutils, regctl):
         ],
         mnemonic = "OCIDescriptor",
         progress_message = "OCI Descriptor %{input}",
+        toolchain = None,
     )
     return descriptor
 

--- a/oci/private/image.bzl
+++ b/oci/private/image.bzl
@@ -12,6 +12,15 @@ _ACCEPTED_TAR_EXTENSIONS = [
     ".tar.zst",
 ]
 
+_OCI_IMAGE_TOOLS_EXEC_GROUP = "oci_image_tools"
+_OCI_IMAGE_TOOLCHAINS = [
+    "@aspect_bazel_lib//lib:jq_toolchain_type",
+    "@aspect_bazel_lib//lib:coreutils_toolchain_type",
+    "@aspect_bazel_lib//lib:zstd_toolchain_type",
+    "@rules_oci//oci:regctl_toolchain_type",
+    "@bazel_tools//tools/sh:toolchain_type",
+]
+
 _DOC = """Build an OCI compatible container image.
 
 Note, most users should use the wrapper macro instead of this rule directly.
@@ -95,7 +104,12 @@ If `group/gid` is not specified, the default group and supplementary groups of t
     "labels": attr.label(doc = "A file containing a dictionary of labels. Each line should be in the form `name=value`.", allow_single_file = True),
     "annotations": attr.label(doc = "A file containing a dictionary of annotations. Each line should be in the form `name=value`.", allow_single_file = True),
     "_image_sh": attr.label(default = "image.sh", allow_single_file = True),
-    "_descriptor_sh": attr.label(default = "descriptor.sh", executable = True, cfg = "exec", allow_single_file = True),
+    "_descriptor_sh": attr.label(
+        default = "descriptor.sh",
+        executable = True,
+        cfg = config.exec(exec_group = _OCI_IMAGE_TOOLS_EXEC_GROUP),
+        allow_single_file = True,
+    ),
 } | util.IS_EXEC_PLATFORM_WINDOWS_ATTRS
 
 def _platform_str(os, arch, variant = None):
@@ -105,13 +119,14 @@ def _platform_str(os, arch, variant = None):
     return json.encode(parts)
 
 def _calculate_descriptor(ctx, idx, layer, zstd, jq, coreutils, regctl):
+    sh = ctx.exec_groups[_OCI_IMAGE_TOOLS_EXEC_GROUP].toolchains["@bazel_tools//tools/sh:toolchain_type"]
     descriptor = ctx.actions.declare_file("%s.%s.descriptor.json" % (ctx.label.name, idx))
     args = ctx.actions.args()
     args.add(layer)
     args.add(descriptor)
     args.add(layer.owner)
     ctx.actions.run(
-        executable = util.maybe_wrap_launcher_for_windows(ctx, ctx.executable._descriptor_sh),
+        executable = util.maybe_wrap_launcher_for_windows(ctx, ctx.executable._descriptor_sh, sh),
         inputs = [layer],
         outputs = [descriptor],
         arguments = [args],
@@ -131,7 +146,7 @@ def _calculate_descriptor(ctx, idx, layer, zstd, jq, coreutils, regctl):
         ],
         mnemonic = "OCIDescriptor",
         progress_message = "OCI Descriptor %{input}",
-        toolchain = None,
+        exec_group = _OCI_IMAGE_TOOLS_EXEC_GROUP,
     )
     return descriptor
 
@@ -141,10 +156,12 @@ def _oci_image_impl(ctx):
     if ctx.attr.base and (ctx.attr.os or ctx.attr.architecture or ctx.attr.variant):
         fail("'os', 'architecture' and 'variant' come from the image provided by 'base' and cannot be overridden.")
 
-    regctl = ctx.toolchains["@rules_oci//oci:regctl_toolchain_type"]
-    jq = ctx.toolchains["@aspect_bazel_lib//lib:jq_toolchain_type"]
-    coreutils = ctx.toolchains["@aspect_bazel_lib//lib:coreutils_toolchain_type"]
-    zstd = ctx.toolchains["@aspect_bazel_lib//lib:zstd_toolchain_type"]
+    image_toolchains = ctx.exec_groups[_OCI_IMAGE_TOOLS_EXEC_GROUP].toolchains
+    regctl = image_toolchains["@rules_oci//oci:regctl_toolchain_type"]
+    jq = image_toolchains["@aspect_bazel_lib//lib:jq_toolchain_type"]
+    coreutils = image_toolchains["@aspect_bazel_lib//lib:coreutils_toolchain_type"]
+    zstd = image_toolchains["@aspect_bazel_lib//lib:zstd_toolchain_type"]
+    sh = image_toolchains["@bazel_tools//tools/sh:toolchain_type"]
 
     output = ctx.actions.declare_directory(ctx.label.name)
 
@@ -254,7 +271,7 @@ def _oci_image_impl(ctx):
         arguments = [args],
         outputs = [output],
         env = action_env,
-        executable = util.maybe_wrap_launcher_for_windows(ctx, builder),
+        executable = util.maybe_wrap_launcher_for_windows(ctx, builder, sh),
         tools = [
             regctl.regctl_info.binary,
             jq.jqinfo.bin,
@@ -263,7 +280,7 @@ def _oci_image_impl(ctx):
         mnemonic = "OCIImage",
         progress_message = "OCI Image %{label}",
         resource_set = resource_set(ctx.attr),
-        toolchain = None,
+        exec_group = _OCI_IMAGE_TOOLS_EXEC_GROUP,
     )
 
     return [
@@ -277,11 +294,8 @@ oci_image = rule(
     implementation = _oci_image_impl,
     attrs = dict(_attrs, **resource_set_attr),
     doc = _DOC,
-    toolchains = [
-        "@aspect_bazel_lib//lib:jq_toolchain_type",
-        "@aspect_bazel_lib//lib:coreutils_toolchain_type",
-        "@aspect_bazel_lib//lib:zstd_toolchain_type",
-        "@rules_oci//oci:regctl_toolchain_type",
-        "@bazel_tools//tools/sh:toolchain_type",
-    ],
+    toolchains = _OCI_IMAGE_TOOLCHAINS,
+    exec_groups = {
+        _OCI_IMAGE_TOOLS_EXEC_GROUP: exec_group(toolchains = _OCI_IMAGE_TOOLCHAINS),
+    },
 )

--- a/oci/private/image_index.bzl
+++ b/oci/private/image_index.bzl
@@ -58,6 +58,12 @@ oci_image_index(
 ```
 """
 
+_OCI_INDEX_TOOLS_EXEC_GROUP = "oci_index_tools"
+_OCI_INDEX_TOOLCHAINS = [
+    "@aspect_bazel_lib//lib:jq_toolchain_type",
+    "@aspect_bazel_lib//lib:coreutils_toolchain_type",
+]
+
 def _image_index_transition_impl(_, attr):
     return [
         {"//command_line_option:platforms": str(platform)}
@@ -105,8 +111,9 @@ def _oci_image_index_impl(ctx):
     if len(ctx.attr.platforms) > 0 and len(ctx.attr.images) != len(ctx.attr.platforms):
         fail("platforms can only be specified when there is exactly one image in the images attribute.")
 
-    jq = ctx.toolchains["@aspect_bazel_lib//lib:jq_toolchain_type"]
-    coreutils = ctx.toolchains["@aspect_bazel_lib//lib:coreutils_toolchain_type"]
+    index_toolchains = ctx.exec_groups[_OCI_INDEX_TOOLS_EXEC_GROUP].toolchains
+    jq = index_toolchains["@aspect_bazel_lib//lib:jq_toolchain_type"]
+    coreutils = index_toolchains["@aspect_bazel_lib//lib:coreutils_toolchain_type"]
 
     launcher = ctx.actions.declare_file("image_index_{}.sh".format(ctx.label.name))
     ctx.actions.expand_template(
@@ -138,7 +145,7 @@ def _oci_image_index_impl(ctx):
         tools = [jq.jqinfo.bin, coreutils.coreutils_info.bin],
         mnemonic = "OCIIndex",
         progress_message = "OCI Index %{label}",
-        toolchain = None,
+        exec_group = _OCI_INDEX_TOOLS_EXEC_GROUP,
     )
 
     return DefaultInfo(files = depset([output]))
@@ -147,8 +154,8 @@ oci_image_index = rule(
     implementation = _oci_image_index_impl,
     attrs = _attrs,
     doc = _DOC,
-    toolchains = [
-        "@aspect_bazel_lib//lib:jq_toolchain_type",
-        "@aspect_bazel_lib//lib:coreutils_toolchain_type",
-    ],
+    toolchains = _OCI_INDEX_TOOLCHAINS,
+    exec_groups = {
+        _OCI_INDEX_TOOLS_EXEC_GROUP: exec_group(toolchains = _OCI_INDEX_TOOLCHAINS),
+    },
 )

--- a/oci/private/load.bzl
+++ b/oci/private/load.bzl
@@ -22,6 +22,13 @@ docker run --rm my-repository:latest
 load("@aspect_bazel_lib//lib:paths.bzl", "BASH_RLOCATION_FUNCTION", "to_rlocation_path")
 load("//oci/private:util.bzl", "util")
 
+_OCI_LOAD_MANIFEST_TOOLS_EXEC_GROUP = "oci_load_manifest_tools"
+_OCI_LOAD_MANIFEST_TOOLCHAINS = [
+    "@bazel_tools//tools/sh:toolchain_type",
+    "@aspect_bazel_lib//lib:coreutils_toolchain_type",
+    "@aspect_bazel_lib//lib:jq_toolchain_type",
+]
+
 doc = """Loads an OCI layout into a container daemon without needing to publish the image first.
 
 Passing anything other than oci_image to the image attribute will lead to build time errors.
@@ -148,8 +155,10 @@ def _get_workspace_root_path(ctx, file):
     return file.root.path
 
 def _load_impl(ctx):
-    jq = ctx.toolchains["@aspect_bazel_lib//lib:jq_toolchain_type"]
-    coreutils = ctx.toolchains["@aspect_bazel_lib//lib:coreutils_toolchain_type"]
+    manifest_toolchains = ctx.exec_groups[_OCI_LOAD_MANIFEST_TOOLS_EXEC_GROUP].toolchains
+    jq = manifest_toolchains["@aspect_bazel_lib//lib:jq_toolchain_type"]
+    coreutils = manifest_toolchains["@aspect_bazel_lib//lib:coreutils_toolchain_type"]
+    sh = manifest_toolchains["@bazel_tools//tools/sh:toolchain_type"]
     bsdtar = ctx.toolchains["@tar.bzl//tar/toolchain:type"]
     bsdtar_target = ctx.toolchains["@tar.bzl//tar/toolchain:target_type"]
 
@@ -187,7 +196,7 @@ def _load_impl(ctx):
     )
     mtree_outputs = [mtree_spec, manifest_json]
     ctx.actions.run(
-        executable = util.maybe_wrap_launcher_for_windows(ctx, executable),
+        executable = util.maybe_wrap_launcher_for_windows(ctx, executable, sh),
         inputs = mtree_inputs,
         outputs = mtree_outputs,
         tools = [
@@ -195,7 +204,7 @@ def _load_impl(ctx):
             coreutils.coreutils_info.bin,
         ],
         mnemonic = "OCITarballManifest",
-        toolchain = None,
+        exec_group = _OCI_LOAD_MANIFEST_TOOLS_EXEC_GROUP,
     )
 
     # This action produces a large output and should rarely be used as it puts load on the cache.
@@ -212,7 +221,7 @@ def _load_impl(ctx):
         outputs = [tarball],
         arguments = [tar_args],
         mnemonic = "OCITarball",
-        toolchain = None,
+        toolchain = "@tar.bzl//tar/toolchain:type",
     )
 
     # Create an executable runner script that will create the tarball at runtime,
@@ -265,5 +274,8 @@ oci_load = rule(
         "@tar.bzl//tar/toolchain:type",
         "@tar.bzl//tar/toolchain:target_type",
     ],
+    exec_groups = {
+        _OCI_LOAD_MANIFEST_TOOLS_EXEC_GROUP: exec_group(toolchains = _OCI_LOAD_MANIFEST_TOOLCHAINS),
+    },
     executable = True,
 )

--- a/oci/private/load.bzl
+++ b/oci/private/load.bzl
@@ -195,6 +195,7 @@ def _load_impl(ctx):
             coreutils.coreutils_info.bin,
         ],
         mnemonic = "OCITarballManifest",
+        toolchain = None,
     )
 
     # This action produces a large output and should rarely be used as it puts load on the cache.
@@ -211,6 +212,7 @@ def _load_impl(ctx):
         outputs = [tarball],
         arguments = [tar_args],
         mnemonic = "OCITarball",
+        toolchain = None,
     )
 
     # Create an executable runner script that will create the tarball at runtime,

--- a/oci/private/util.bzl
+++ b/oci/private/util.bzl
@@ -189,7 +189,7 @@ def _warning(rctx, message):
         "\033[0;33mWARNING:\033[0m {}".format(message),
     ], quiet = False)
 
-def _maybe_wrap_launcher_for_windows(ctx, bash_launcher):
+def _maybe_wrap_launcher_for_windows(ctx, bash_launcher, sh_toolchain = None):
     """Windows cannot directly execute a shell script.
 
     Wrap with a .bat file that executes the shell script with a bash command.
@@ -204,6 +204,9 @@ def _maybe_wrap_launcher_for_windows(ctx, bash_launcher):
     """
     if not is_windows_exec(ctx):
         return bash_launcher
+
+    if sh_toolchain == None:
+        sh_toolchain = ctx.toolchains["@bazel_tools//tools/sh:toolchain_type"]
 
     win_launcher = ctx.actions.declare_file("wrap_%s.bat" % ctx.label.name)
     ctx.actions.write(
@@ -223,7 +226,7 @@ if defined args (
 )
 "{bash_bin}" -c "%parent_dir%{launcher} !args!"
 """.format(
-            bash_bin = ctx.toolchains["@bazel_tools//tools/sh:toolchain_type"].path,
+            bash_bin = sh_toolchain.path,
             launcher = paths.relativize(bash_launcher.path, win_launcher.dirname),
         ),
         is_executable = True,


### PR DESCRIPTION
The --incompatible_auto_exec_groups flag requires Starlark actions to declare whether their executable/tools come from an action toolchain. This is not a Bazel default today, but it is exposed through strict preset configurations and is intended to catch rules that rely on implicit action toolchain inference.

The descriptor and load helpers combine tools from several toolchains. Mark those helper actions with toolchain = None, matching the main OCI image action, so their action toolchain behavior is explicit without changing their inputs or execution model.